### PR TITLE
Fix use of `bStillWaiting`

### DIFF
--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -1088,6 +1088,8 @@ bool OPUNetTransportLayer::SendUntilStatusUpdate(Packet *packet, int untilStatus
 			index = playerNetIDList[playerNum] & 7;
 			if (peerInfo[index].status != untilStatus)
 			{
+				// Must wait for a response from this player
+				bStillWaiting = true;
 				// Sent packet to this player
 				SendTo(*packet, peerInfo[index].address);
 			}


### PR DESCRIPTION
Previously this variable was basically unused, leading to an always success condition. This could lead to failures to wait for status updates from all players.

Bug spotted while working on #21.
