### PR TITLE
Add `override` to virtual methods

### DIFF
--- a/OPUNetGameProtocol.h
+++ b/OPUNetGameProtocol.h
@@ -17,8 +17,8 @@ public:
 
 public:
 	// Virtual member functions
-	virtual bool IsEnabled() {return 1;};
-	virtual bool DoStart()
+	virtual bool IsEnabled() override {return 1;};
+	virtual bool DoStart() override
 	{
 		int retVal;
 
@@ -32,7 +32,7 @@ public:
 		// Return if the game was cancelled (or should be starting)
 		return (retVal != 0);
 	};
-	virtual bool F1() {return 1;};
-	virtual const char* GetProtocolName() {return "OPU.Net";};
+	virtual bool F1() override {return 1;};
+	virtual const char* GetProtocolName() override {return "OPU.Net";};
 };
 

--- a/OPUNetGameSelectWnd.h
+++ b/OPUNetGameSelectWnd.h
@@ -17,8 +17,8 @@ class OPUNetGameSelectWnd : public IDlgWnd
 {
 public:
 	// Virtual functions
-	virtual ~OPUNetGameSelectWnd();
-	virtual int DlgProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
+	virtual ~OPUNetGameSelectWnd() override;
+	virtual int DlgProc(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
 	// Constructor
 	OPUNetGameSelectWnd();

--- a/OPUNetTransportLayer.h
+++ b/OPUNetTransportLayer.h
@@ -57,20 +57,20 @@ public:
 
 	// Virtual member functions
 	// ------------------------
-	virtual ~OPUNetTransportLayer();
-	virtual int GetHostPlayerNetID();
-	virtual void ShutDownInvite();
-	virtual int ReplicatePlayersList();
-	virtual int GetOpponentNetIDList(int netIDList[], int maxNumID);
-	virtual void RemovePlayer(int playerNetID);
-	virtual int Send(Packet* packet);
-	virtual int Receive(Packet* packet);
-	virtual int IsHost();
-	virtual int IsValidPlayer();
-	virtual int F1();
-	virtual int GetAddressString(int playerNetID, char* addressString, int bufferSize);
-	virtual int ResetTrafficCounters();
-	virtual int GetTrafficCounts(TrafficCounters* trafficCounters);
+	virtual ~OPUNetTransportLayer() override;
+	virtual int GetHostPlayerNetID() override;
+	virtual void ShutDownInvite() override;
+	virtual int ReplicatePlayersList() override;
+	virtual int GetOpponentNetIDList(int netIDList[], int maxNumID) override;
+	virtual void RemovePlayer(int playerNetID) override;
+	virtual int Send(Packet* packet) override;
+	virtual int Receive(Packet* packet) override;
+	virtual int IsHost() override;
+	virtual int IsValidPlayer() override;
+	virtual int F1()  override;
+	virtual int GetAddressString(int playerNetID, char* addressString, int bufferSize) override;
+	virtual int ResetTrafficCounters() override;
+	virtual int GetTrafficCounts(TrafficCounters* trafficCounters) override;
 
 private:
 	// Private member functions


### PR DESCRIPTION
This should ensure compile time errors if base class methods are renamed or have their signatures changed, and the derived class is not also updated.

As some base classes have unnamed methods (`F1`), this may be likely to happen. I also have plans to adjust a few signatures from pointer to reference types.
