### PR TITLE
Add op2ext as a submodule and hook to Visual Studio project files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "OP2Internal"]
 	path = OP2Internal
 	url = https://github.com/OutpostUniverse/OP2Internal.git
+[submodule "op2ext"]
+	path = op2ext
+	url = https://github.com/OutpostUniverse/op2ext.git

--- a/NetFixClient.sln
+++ b/NetFixClient.sln
@@ -7,6 +7,10 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NetFixClient", "NetFixClien
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "OP2Internal", "OP2Internal\OP2Internal.vcxproj", "{97594BB1-793F-379B-F6AB-040AC8FE1424}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "op2ext", "..\op2ext\op2ext.vcxproj", "{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Outpost2DLL", "op2ext\Submodules\Outpost2DLL\Outpost2DLL.vcxproj", "{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86
@@ -21,6 +25,14 @@ Global
 		{97594BB1-793F-379B-F6AB-040AC8FE1424}.Debug|x86.Build.0 = Debug|Win32
 		{97594BB1-793F-379B-F6AB-040AC8FE1424}.Release|x86.ActiveCfg = Release|Win32
 		{97594BB1-793F-379B-F6AB-040AC8FE1424}.Release|x86.Build.0 = Release|Win32
+		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Debug|x86.ActiveCfg = Debug|Win32
+		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Debug|x86.Build.0 = Debug|Win32
+		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Release|x86.ActiveCfg = Release|Win32
+		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Release|x86.Build.0 = Release|Win32
+		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Debug|x86.ActiveCfg = Debug|Win32
+		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Debug|x86.Build.0 = Debug|Win32
+		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Release|x86.ActiveCfg = Release|Win32
+		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NetFixClient.sln
+++ b/NetFixClient.sln
@@ -7,7 +7,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NetFixClient", "NetFixClien
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "OP2Internal", "OP2Internal\OP2Internal.vcxproj", "{97594BB1-793F-379B-F6AB-040AC8FE1424}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "op2ext", "..\op2ext\op2ext.vcxproj", "{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "op2ext", "op2ext\op2ext.vcxproj", "{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Outpost2DLL", "op2ext\Submodules\Outpost2DLL\Outpost2DLL.vcxproj", "{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}"
 EndProject

--- a/NetFixClient.vcxproj
+++ b/NetFixClient.vcxproj
@@ -54,7 +54,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <Optimization>MinSpace</Optimization>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>OP2Internal;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>OP2Internal;op2ext;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;OP2_NO_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
@@ -85,7 +85,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <Optimization>Disabled</Optimization>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>OP2Internal;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>OP2Internal;op2ext;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;DEBUG;_WINDOWS;_USRDLL;OP2_NO_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
@@ -129,6 +129,9 @@
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\op2ext\op2ext.vcxproj">
+      <Project>{6de3610c-c9ee-4fd3-bbd7-66382c16fde9}</Project>
+    </ProjectReference>
     <ProjectReference Include="OP2Internal\OP2Internal.vcxproj">
       <Project>{97594bb1-793f-379b-f6ab-040ac8fe1424}</Project>
     </ProjectReference>


### PR DESCRIPTION
Had to bring in OP2Internal as op2ext's submodule and hook to NetFixClient's project files. Otherwise, op2ext would not properly compile.

Will look at the recommendation about the environment variable later or in a different branch.

Closes #24 

-Brett