### PR TITLE
Separate Logging From Formatting Functions

### DIFF
--- a/Log.cpp
+++ b/Log.cpp
@@ -4,51 +4,62 @@
 #include <objbase.h>
 #include <iostream>
 #include <fstream>
-
+#include <sstream>
+#include <string>
 
 // Global Debug file
 std::ofstream logFile("log.txt");
 
+std::string FormatIP4Address(unsigned long ip);
+std::string FormatPlayerNetID(int playerNetID);
 
 void Log(char* string)
 {
 	logFile << string << std::endl;
 }
 
-void DumpIP(unsigned long ip)
+std::string FormatIP4Address(unsigned long ip)
 {
-	logFile << (ip & 255) 
-		<< "." << ((ip >> 8) & 255) 
-		<< "." << ((ip >> 16) & 255) 
-		<< "." << ((ip >> 24) & 255);
+	std::stringstream ss;
+
+	ss << (ip & 255) << "." 
+		<< ((ip >> 8) & 255) << "." 
+		<< ((ip >> 16) & 255) << "." 
+		<< ((ip >> 24) & 255);
+
+	return ss.str();
 }
 
-void DumpAddr(sockaddr_in &addr)
+void LogAddress(sockaddr_in &addr)
 {
 	logFile << "(AF:" << addr.sin_family << ") ";
-	DumpIP(addr.sin_addr.s_addr);
+	logFile << FormatIP4Address(addr.sin_addr.s_addr);
 	logFile << ":" << ntohs(addr.sin_port);
 }
 
-void DumpPlayerNetID(int playerNetID)
+std::string FormatPlayerNetID(int playerNetID)
 {
-	logFile << "[" << (playerNetID & ~7) << "." << (playerNetID & 7) << "]";
+	std::stringstream ss;
+
+	ss << "[" << (playerNetID & ~7) << "." << (playerNetID & 7) << "]";
+
+	return ss.str();
 }
 
-void DumpAddrList(PeerInfo* peerInfo)
+void LogAddressList(PeerInfo* peerInfo)
 {
 	for (int i = 0; i < MaxRemotePlayers; ++i)
 	{
 		logFile << " " << i << ") {" << peerInfo[i].status << ", ";
-		//DumpIP(peerInfo[i].address.sin_addr.s_addr);
-		DumpAddr(peerInfo[i].address);
+		//logFile << FormatIP4Address(peerInfo[i].address.sin_addr.s_addr);
+		LogAddress(peerInfo[i].address);
 		logFile << ", ";
-		DumpPlayerNetID(peerInfo[i].playerNetID);
+		logFile << FormatPlayerNetID(peerInfo[i].playerNetID);
 		logFile << "}" << std::endl;
 	}
 }
 
-void DumpGuid(GUID &guid)
+void LogGuid(GUID &guid)
 {
 	logFile << std::hex << "{" << guid.Data1 << "-" << guid.Data2 << "-" << guid.Data3 << "-";
 	for (int i = 0; i < 8; ++i)	{
@@ -57,7 +68,7 @@ void DumpGuid(GUID &guid)
 	logFile << "}" << std::dec;
 }
 
-void DumpPacket(OP2Internal::Packet& packet)
+void LogPacket(OP2Internal::Packet& packet)
 {
 	logFile << " Source: " << packet.header.sourcePlayerNetID << std::endl;
 	logFile << " Dest  : " << packet.header.destPlayerNetID << std::endl;

--- a/Log.h
+++ b/Log.h
@@ -15,9 +15,8 @@ extern std::ofstream logFile;
 
 
 void Log(char* string);
-void DumpIP(unsigned long ip);
-void DumpAddr(sockaddr_in &addr);
-void DumpPlayerNetID(int playerNetID);
-void DumpAddrList(PeerInfo* peerInfo);
-void DumpGuid(GUID &guid);
-void DumpPacket(OP2Internal::Packet& packet);
+
+void LogAddress(sockaddr_in &addr);
+void LogAddressList(PeerInfo* peerInfo);
+void LogGuid(GUID &guid);
+void LogPacket(OP2Internal::Packet& packet);

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -176,7 +176,7 @@ logFile << "Bound to server port: " << port << std::endl;
 
 // **DEBUG**
 logFile << " Session ID: ";
-DumpGuid(hostedGameInfo.sessionIdentifier);
+LogGuid(hostedGameInfo.sessionIdentifier);
 logFile << std::endl;
 
 	// Create a Host playerNetID
@@ -265,7 +265,7 @@ bool OPUNetTransportLayer::SearchForGames(char* hostAddressString, unsigned shor
 
 // **DEBUG**
 logFile << "Search for games: ";
-DumpAddr(hostAddress);
+LogAddress(hostAddress);
 logFile << std::endl;
 
 	// Send the HostGameSearchQuery
@@ -300,11 +300,11 @@ bool OPUNetTransportLayer::JoinGame(HostedGameInfo &game, const char* password)
 
 // **DEBUG**
 logFile << "Sending join request: ";
-DumpAddr(game.address);
+LogAddress(game.address);
 logFile << std::endl << "  Session ID: ";
-DumpGuid(packet.tlMessage.joinRequest.sessionIdentifier);
+LogGuid(packet.tlMessage.joinRequest.sessionIdentifier);
 logFile << std::endl;
-//DumpPacket(packet);
+//LogPacket(packet);
 
 	sockaddr_in gameServerAddr;
 	// Check if a Game Server is set
@@ -340,7 +340,7 @@ void OPUNetTransportLayer::OnJoinAccepted(Packet &packet)
 	peerInfo[localPlayerNum].status = 2;
 
 logFile << "OnJoinAcecpted" << std::endl;
-DumpAddrList(peerInfo);
+LogAddressList(peerInfo);
 
 	// Update num players (for quit messages from cancelled games)
 	numPlayers = 1;
@@ -690,7 +690,7 @@ int OPUNetTransportLayer::Receive(Packet& packet)
 			if (expectedPlayerNetID != 0 && expectedPlayerNetID != sourcePlayerNetID)
 			{
 				logFile << "Received packet with bad sourcePlayerNetID: " << sourcePlayerNetID << " from ";
-				DumpAddr(from);
+				LogAddress(from);
 				logFile << std::endl;
 				logFile << " Packet.type = " << (int)packet.header.type << std::endl;
 				logFile << " Packet.commandType = " << packet.tlMessage.tlHeader.commandType << std::endl;
@@ -985,7 +985,7 @@ bool OPUNetTransportLayer::SendTo(Packet& packet, sockaddr_in& to)
 	{
 		// **DEBUG**
 		logFile << "SendTo error: ";
-		DumpAddr(to);
+		LogAddress(to);
 		logFile << std::endl;
 		logFile << WSAGetLastError() << std::endl;
 	}
@@ -1100,7 +1100,7 @@ bool OPUNetTransportLayer::DoImmediateProcessing(Packet &packet, sockaddr_in &fr
 				tlMessage.tlHeader.commandType = tlcJoinGranted;
 				// **DEBUG**
 				logFile << "Client join accepted: ";
-				DumpAddr(from);
+				LogAddress(from);
 				logFile << " (" << tlMessage.joinReply.newPlayerNetID << ")" << std::endl;
 
 				// Check if a forced return port has been set
@@ -1116,7 +1116,7 @@ bool OPUNetTransportLayer::DoImmediateProcessing(Packet &packet, sockaddr_in &fr
 				tlMessage.tlHeader.commandType = tlcJoinRefused;
 				// **DEBUG**
 				logFile << "Client join refused: ";
-				DumpAddr(from);
+				LogAddress(from);
 				logFile << std::endl;
 			}
 
@@ -1130,7 +1130,7 @@ bool OPUNetTransportLayer::DoImmediateProcessing(Packet &packet, sockaddr_in &fr
 				return true;		// Packet handled (discard)
 // **DEBUG**
 logFile << "Game Search Query: ";
-DumpAddr(from);
+LogAddress(from);
 logFile << std::endl;
 			// Verify Game Identifier
 			if (tlMessage.searchQuery.gameIdentifier != gameIdentifier)
@@ -1160,7 +1160,7 @@ logFile << std::endl;
 
 			// Log JoinHelpRequest parameters
 			logFile << "JoinHelpRequest: Client: ";
-			DumpAddr(tlMessage.joinHelpRequest.clientAddr);
+			LogAddress(tlMessage.joinHelpRequest.clientAddr);
 			logFile << "  Return Port: " << tlMessage.joinHelpRequest.returnPortNum << std::endl;
 			// Send something to create router mappings
 			tlMessage.joinHelpRequest.clientAddr.sin_family = AF_INET;
@@ -1207,7 +1207,7 @@ logFile << "GameStarting" << std::endl;
 
 // **DEBUG**
 logFile << "Replicated Players List:" << std::endl;
-DumpAddrList(peerInfo);
+LogAddressList(peerInfo);
 
 				// Form a new packet to return to the game
 				packet.header.sourcePlayerNetID = 0;
@@ -1261,7 +1261,7 @@ DumpAddrList(peerInfo);
 		case tlcHostedGameSearchReply:		// [Custom format]
 // **DEBUG**
 logFile << "Hosted Game Search Reply: ";
-DumpAddr(from);
+LogAddress(from);
 logFile << std::endl;
 			// Verify packet size
 			if (packet.header.sizeOfPayload != sizeof(HostedGameSearchReply))
@@ -1370,7 +1370,7 @@ void OPUNetTransportLayer::CheckSourcePort(Packet &packet, sockaddr_in &from)
 		{
 			// Port mismatch. Issue warning
 			logFile << "Packet from player " << sourcePlayerIndex << " (";
-			DumpAddr(from);
+			LogAddress(from);
 			logFile << ") received on unexpected port (" << ntohs(sourcePort) << " instead of " << ntohs(expectedPort) << ")  [PlayerNetId: " << sourcePlayerNetId << "]" << std::endl;
 		}
 		// Update the source port


### PR DESCRIPTION
I think Log and Format are more descriptive than Dump.

I think one of the next steps is removing the extern declared fstream logger, so only log.cpp can actually log something. Everything else will just call a function from log.