### PR TITLE
Pull game directory from op2ext

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -1,4 +1,3 @@
-#include "Log.h"
 #include "op2ext.h"
 #define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
 #include <windows.h>
@@ -11,6 +10,8 @@ using namespace OP2Internal;
 #include <fstream>
 #include <cstddef>
 #include <string>
+#include <algorithm>
+
 extern std::ofstream logFile;
 
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -1,3 +1,4 @@
+#include "op2ext.h"
 #define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
 #include <windows.h>
 
@@ -8,6 +9,8 @@ using namespace OP2Internal;
 #include "OPUNetGameProtocol.h"
 
 #include <fstream>
+#include <cstddef>
+#include <string>
 extern std::ofstream logFile;
 
 
@@ -36,6 +39,8 @@ BOOL APIENTRY DllMain(HANDLE hModule, DWORD  ul_reason_for_call, LPVOID lpReserv
     return TRUE;
 }
 
+std::string GetOutpost2Directory();
+
 extern "C" __declspec(dllexport) void InitMod(char* iniSectionName)
 {
 	// Sanity check the DLL load address
@@ -57,10 +62,24 @@ extern "C" __declspec(dllexport) void InitMod(char* iniSectionName)
 	// Store the .ini section name
 	strncpy(sectionName, iniSectionName, sizeof(sectionName));
 
-	int protocolIndex;
-	// Get button index to replace functionality of
-	protocolIndex = GetPrivateProfileInt(sectionName, "ProtocolIndex", DefaultProtocolIndex, ".\\Outpost2.ini");
+
+	// Get multiplayer button index that NetFix will replace
+	const std::string iniPath = GetOutpost2Directory() + "Outpost2.ini"; 
+
+	int protocolIndex = GetPrivateProfileInt(sectionName, "ProtocolIndex", DefaultProtocolIndex, iniPath.c_str());
 	logFile << "[" << sectionName << "]" << " ProtocolIndex = " << protocolIndex << std::endl;
 	// Set a new multiplayer protocol type
 	protocolList[protocolIndex].netGameProtocol = &opuNetGameProtocol;
+}
+
+std::string GetOutpost2Directory()
+{
+	char buffer[MAX_PATH];
+	std::size_t bufferSize = GetGameDir_s(buffer, MAX_PATH);
+
+	if (bufferSize != 0) {
+		throw std::runtime_error("Absolute directory to Outpost 2 must be less than " + MAX_PATH);
+	}
+
+	return std::string(buffer);
 }

--- a/Main.cpp
+++ b/Main.cpp
@@ -64,10 +64,8 @@ extern "C" __declspec(dllexport) void InitMod(char* iniSectionName)
 	// Store the .ini section name
 	strncpy(sectionName, iniSectionName, sizeof(sectionName));
 
-
 	// Get multiplayer button index that NetFix will replace
-	const std::string iniPath = GetOutpost2Directory() + "Outpost2.ini"; 
-
+	const std::string iniPath = GetOutpost2Directory() + "Outpost2.ini";
 	int protocolIndex = GetPrivateProfileInt(sectionName, "ProtocolIndex", DefaultProtocolIndex, iniPath.c_str());
 	logFile << "[" << sectionName << "]" << " ProtocolIndex = " << protocolIndex << std::endl;
 	// Set a new multiplayer protocol type

--- a/Main.cpp
+++ b/Main.cpp
@@ -74,12 +74,17 @@ extern "C" __declspec(dllexport) void InitMod(char* iniSectionName)
 
 std::string GetOutpost2Directory()
 {
-	char buffer[MAX_PATH];
-	std::size_t bufferSize = GetGameDir_s(buffer, MAX_PATH);
+	std::string buffer;
 
-	if (bufferSize != 0) {
-		throw std::runtime_error("Absolute directory to Outpost 2 must be less than " + MAX_PATH);
-	}
+	// Pass size of 0 to get exact buffer size
+	std::size_t bufferSize = GetGameDir_s(&buffer[0], 0);
 
-	return std::string(buffer);
+	buffer.resize(bufferSize);
+	GetGameDir_s(&buffer[0], bufferSize);
+
+	// String concatinations (string1 + string2) will not provide expected results
+	// if the std::string explicity has a null terminator
+	buffer.erase(std::find(buffer.begin(), buffer.end(), '\0'), buffer.end());
+
+	return buffer;
 }


### PR DESCRIPTION
This allows attaching a debugger and still finding the correct location of the .ini file. Otherwise if the debugger is attached, the default protocol index of 4 is returned (because .ini file is not found) which makes it appear as if the module is not loading properly. Guess this whole problem may not exist depending on how we finalize setting protocolIndex. Although we are pulling other values from the .ini file, so this piece of code should be relevant in other parts of the project.

I wanted to find a solution that would allow Outpost 2 to be buried in a directory deeper than MAX_PATH, but didn't come up with anything useful. 

I'm okay in this form or continuing to refactor.