### PR TITLE
Silence column text warnings in Mingw

### DIFF
--- a/OPUNetGameSelectWnd.cpp
+++ b/OPUNetGameSelectWnd.cpp
@@ -198,22 +198,22 @@ void OPUNetGameSelectWnd::OnInit()
 	lvColumn.mask = LVCF_WIDTH | LVCF_TEXT;
 	// Insert each column
 	lvColumn.cx = 100;
-	lvColumn.pszText = "Host";
+	lvColumn.pszText = const_cast<char*>("Host");
 	SendDlgItemMessage(this->hWnd, IDC_GamesList, LVM_INSERTCOLUMN, 0, (LPARAM)&lvColumn);
 	lvColumn.cx = 100;
-	lvColumn.pszText = "Game Type";
+	lvColumn.pszText = const_cast<char*>("Game Type");
 	SendDlgItemMessage(this->hWnd, IDC_GamesList, LVM_INSERTCOLUMN, 1, (LPARAM)&lvColumn);
 	lvColumn.cx = 57;
-	lvColumn.pszText = "# Players";
+	lvColumn.pszText = const_cast<char*>("# Players");
 	SendDlgItemMessage(this->hWnd, IDC_GamesList, LVM_INSERTCOLUMN, 2, (LPARAM)&lvColumn);
 	lvColumn.cx = 70;
-	lvColumn.pszText = "IP";
+	lvColumn.pszText = const_cast<char*>("IP");
 	SendDlgItemMessage(this->hWnd, IDC_GamesList, LVM_INSERTCOLUMN, 3, (LPARAM)&lvColumn);
 	lvColumn.cx = 42;
-	lvColumn.pszText = "Port";
+	lvColumn.pszText = const_cast<char*>("Port");
 	SendDlgItemMessage(this->hWnd, IDC_GamesList, LVM_INSERTCOLUMN, 4, (LPARAM)&lvColumn);
 	lvColumn.cx = 40;
-	lvColumn.pszText = "Ping";
+	lvColumn.pszText = const_cast<char*>("Ping");
 	SendDlgItemMessage(this->hWnd, IDC_GamesList, LVM_INSERTCOLUMN, 5, (LPARAM)&lvColumn);
 	
 	// Turn on full row select in the list view


### PR DESCRIPTION
The `pszText` field can be used to set information, or to retrieve information from a list view control. When retrieving information, the `pszText` field point to a buffer to receive the information, while a `cchTextMax` field gives the buffer size. As this field is able to point to a modifiable buffer, it is not declared `const`. As it is not declared `const`, it generates compiler warnings when a string literal is assigned to it.

This inserts `const_cast` to silence the warning when setting column text labels.
