### PR TITLE
Extract Format methods from logging code

### DIFF
--- a/Log.cpp
+++ b/Log.cpp
@@ -60,8 +60,7 @@ void LogAddressList(PeerInfo* peerInfo)
 	for (int i = 0; i < MaxRemotePlayers; ++i)
 	{
 		logFile << " " << i << ") {" << peerInfo[i].status << ", ";
-		//logFile << FormatIP4Address(peerInfo[i].address.sin_addr.s_addr);
-		LogAddress(peerInfo[i].address);
+		logFile << FormatAddress(peerInfo[i].address);
 		logFile << ", ";
 		logFile << FormatPlayerNetID(peerInfo[i].playerNetID);
 		logFile << "}" << std::endl;

--- a/Log.cpp
+++ b/Log.cpp
@@ -12,7 +12,7 @@
 std::ofstream logFile("log.txt");
 
 
-std::string FormatAddress(sockaddr_in& address)
+std::string FormatAddress(const sockaddr_in& address)
 {
 	std::stringstream ss;
 
@@ -35,7 +35,7 @@ std::string FormatIP4Address(unsigned long ip)
 	return ss.str();
 }
 
-std::string FormatPlayerList(PeerInfo* peerInfo)
+std::string FormatPlayerList(const PeerInfo* peerInfo)
 {
 	std::stringstream ss;
 
@@ -60,7 +60,7 @@ std::string FormatPlayerNetID(int playerNetID)
 	return ss.str();
 }
 
-std::string FormatGuid(GUID& guid)
+std::string FormatGuid(const GUID& guid)
 {
 	std::stringstream ss;
 
@@ -73,7 +73,7 @@ std::string FormatGuid(GUID& guid)
 	return ss.str();
 }
 
-std::string FormatPacket(OP2Internal::Packet& packet)
+std::string FormatPacket(const OP2Internal::Packet& packet)
 {
 	std::stringstream ss;
 
@@ -93,22 +93,22 @@ void Log(const char* string)
 	logFile << string << std::endl;
 }
 
-void LogAddress(sockaddr_in &address)
+void LogAddress(const sockaddr_in &address)
 {
 	logFile << FormatAddress(address); // Note: No std::endl
 }
 
-void LogAddressList(PeerInfo* peerInfo)
+void LogAddressList(const PeerInfo* peerInfo)
 {
 	logFile << FormatPlayerList(peerInfo); // Note: std::endl already included
 }
 
-void LogGuid(GUID &guid)
+void LogGuid(const GUID &guid)
 {
 	logFile << FormatGuid(guid); // Note: No std::endl;
 }
 
-void LogPacket(OP2Internal::Packet& packet)
+void LogPacket(const OP2Internal::Packet& packet)
 {
 	logFile << FormatPacket(packet); // Note: std::endl already included
 }

--- a/Log.cpp
+++ b/Log.cpp
@@ -35,6 +35,22 @@ std::string FormatIP4Address(unsigned long ip)
 	return ss.str();
 }
 
+std::string FormatPlayerList(PeerInfo* peerInfo)
+{
+	std::stringstream ss;
+
+	for (int i = 0; i < MaxRemotePlayers; ++i)
+	{
+		ss << " " << i << ") {" << peerInfo[i].status << ", ";
+		ss << FormatAddress(peerInfo[i].address);
+		ss << ", ";
+		ss << FormatPlayerNetID(peerInfo[i].playerNetID);
+		ss << "}" << std::endl;
+	}
+
+	return ss.str();
+}
+
 std::string FormatPlayerNetID(int playerNetID)
 {
 	std::stringstream ss;
@@ -57,14 +73,7 @@ void LogAddress(sockaddr_in &address)
 
 void LogAddressList(PeerInfo* peerInfo)
 {
-	for (int i = 0; i < MaxRemotePlayers; ++i)
-	{
-		logFile << " " << i << ") {" << peerInfo[i].status << ", ";
-		logFile << FormatAddress(peerInfo[i].address);
-		logFile << ", ";
-		logFile << FormatPlayerNetID(peerInfo[i].playerNetID);
-		logFile << "}" << std::endl;
-	}
+	logFile << FormatPlayerList(peerInfo); // Note: std::endl already included
 }
 
 void LogGuid(GUID &guid)

--- a/Log.cpp
+++ b/Log.cpp
@@ -93,7 +93,7 @@ void Log(const char* string)
 	logFile << string << std::endl;
 }
 
-void LogAddress(const sockaddr_in &address)
+void LogAddress(const sockaddr_in& address)
 {
 	logFile << FormatAddress(address); // Note: No std::endl
 }
@@ -103,7 +103,7 @@ void LogAddressList(const PeerInfo* peerInfo)
 	logFile << FormatPlayerList(peerInfo); // Note: std::endl already included
 }
 
-void LogGuid(const GUID &guid)
+void LogGuid(const GUID& guid)
 {
 	logFile << FormatGuid(guid); // Note: No std::endl;
 }

--- a/Log.cpp
+++ b/Log.cpp
@@ -11,8 +11,6 @@
 // Global Debug file
 std::ofstream logFile("log.txt");
 
-std::string FormatIP4Address(unsigned long ip);
-std::string FormatPlayerNetID(int playerNetID);
 
 void Log(const char* string)
 {

--- a/Log.cpp
+++ b/Log.cpp
@@ -73,6 +73,20 @@ std::string FormatGuid(GUID& guid)
 	return ss.str();
 }
 
+std::string FormatPacket(OP2Internal::Packet& packet)
+{
+	std::stringstream ss;
+
+	ss << " Source: " << packet.header.sourcePlayerNetID << std::endl;
+	ss << " Dest  : " << packet.header.destPlayerNetID << std::endl;
+	ss << " Size  : " << static_cast<unsigned int>(packet.header.sizeOfPayload) << std::endl;
+	ss << " type  : " << static_cast<unsigned int>(packet.header.type) << std::endl;
+	ss << " checksum : " << std::hex << packet.Checksum() << std::dec << std::endl;
+	ss << " commandType : " << packet.tlMessage.tlHeader.commandType << std::endl;
+
+	return ss.str();
+}
+
 
 void Log(const char* string)
 {
@@ -96,10 +110,5 @@ void LogGuid(GUID &guid)
 
 void LogPacket(OP2Internal::Packet& packet)
 {
-	logFile << " Source: " << packet.header.sourcePlayerNetID << std::endl;
-	logFile << " Dest  : " << packet.header.destPlayerNetID << std::endl;
-	logFile << " Size  : " << static_cast<unsigned int>(packet.header.sizeOfPayload) << std::endl;
-	logFile << " type  : " << static_cast<unsigned int>(packet.header.type) << std::endl;
-	logFile << " checksum : " << std::hex << packet.Checksum() << std::dec << std::endl;
-	logFile << " commandType : " << packet.tlMessage.tlHeader.commandType << std::endl;
+	logFile << FormatPacket(packet); // Note: std::endl already included
 }

--- a/Log.cpp
+++ b/Log.cpp
@@ -60,6 +60,19 @@ std::string FormatPlayerNetID(int playerNetID)
 	return ss.str();
 }
 
+std::string FormatGuid(GUID& guid)
+{
+	std::stringstream ss;
+
+	ss << std::hex << "{" << guid.Data1 << "-" << guid.Data2 << "-" << guid.Data3 << "-";
+	for (int i = 0; i < 8; ++i)	{
+		ss << (int)guid.Data4[i];
+	}
+	ss << "}" << std::dec;
+
+	return ss.str();
+}
+
 
 void Log(const char* string)
 {
@@ -78,11 +91,7 @@ void LogAddressList(PeerInfo* peerInfo)
 
 void LogGuid(GUID &guid)
 {
-	logFile << std::hex << "{" << guid.Data1 << "-" << guid.Data2 << "-" << guid.Data3 << "-";
-	for (int i = 0; i < 8; ++i)	{
-		logFile << (int)guid.Data4[i];
-	}
-	logFile << "}" << std::dec;
+	logFile << FormatGuid(guid); // Note: No std::endl;
 }
 
 void LogPacket(OP2Internal::Packet& packet)

--- a/Log.cpp
+++ b/Log.cpp
@@ -12,11 +12,6 @@
 std::ofstream logFile("log.txt");
 
 
-void Log(const char* string)
-{
-	logFile << string << std::endl;
-}
-
 std::string FormatIP4Address(unsigned long ip)
 {
 	std::stringstream ss;
@@ -29,13 +24,6 @@ std::string FormatIP4Address(unsigned long ip)
 	return ss.str();
 }
 
-void LogAddress(sockaddr_in &addr)
-{
-	logFile << "(AF:" << addr.sin_family << ") ";
-	logFile << FormatIP4Address(addr.sin_addr.s_addr);
-	logFile << ":" << ntohs(addr.sin_port);
-}
-
 std::string FormatPlayerNetID(int playerNetID)
 {
 	std::stringstream ss;
@@ -43,6 +31,19 @@ std::string FormatPlayerNetID(int playerNetID)
 	ss << "[" << (playerNetID & ~7) << "." << (playerNetID & 7) << "]";
 
 	return ss.str();
+}
+
+
+void Log(const char* string)
+{
+	logFile << string << std::endl;
+}
+
+void LogAddress(sockaddr_in &addr)
+{
+	logFile << "(AF:" << addr.sin_family << ") ";
+	logFile << FormatIP4Address(addr.sin_addr.s_addr);
+	logFile << ":" << ntohs(addr.sin_port);
 }
 
 void LogAddressList(PeerInfo* peerInfo)

--- a/Log.cpp
+++ b/Log.cpp
@@ -12,6 +12,17 @@
 std::ofstream logFile("log.txt");
 
 
+std::string FormatAddress(sockaddr_in& address)
+{
+	std::stringstream ss;
+
+	ss << "(AF:" << address.sin_family << ") ";
+	ss << FormatIP4Address(address.sin_addr.s_addr);
+	ss << ":" << ntohs(address.sin_port);
+
+	return ss.str();
+}
+
 std::string FormatIP4Address(unsigned long ip)
 {
 	std::stringstream ss;
@@ -39,11 +50,9 @@ void Log(const char* string)
 	logFile << string << std::endl;
 }
 
-void LogAddress(sockaddr_in &addr)
+void LogAddress(sockaddr_in &address)
 {
-	logFile << "(AF:" << addr.sin_family << ") ";
-	logFile << FormatIP4Address(addr.sin_addr.s_addr);
-	logFile << ":" << ntohs(addr.sin_port);
+	logFile << FormatAddress(address); // Note: No std::endl
 }
 
 void LogAddressList(PeerInfo* peerInfo)

--- a/Log.h
+++ b/Log.h
@@ -20,7 +20,7 @@ std::string FormatPlayerNetID(int playerNetID);
 
 void Log(const char* string);
 
-void LogAddress(sockaddr_in &addr);
-void LogAddressList(PeerInfo* peerInfo);
-void LogGuid(GUID &guid);
-void LogPacket(OP2Internal::Packet& packet);
+void LogAddress(const sockaddr_in &addr);
+void LogAddressList(const PeerInfo* peerInfo);
+void LogGuid(const GUID &guid);
+void LogPacket(const OP2Internal::Packet& packet);

--- a/Log.h
+++ b/Log.h
@@ -14,8 +14,12 @@ namespace OP2Internal {
 extern std::ofstream logFile;
 
 
+std::string FormatAddress(const sockaddr_in& address);
 std::string FormatIP4Address(unsigned long ip);
+std::string FormatPlayerList(const PeerInfo* peerInfo);
 std::string FormatPlayerNetID(int playerNetID);
+std::string FormatGuid(const GUID& guid);
+std::string FormatPacket(const OP2Internal::Packet& packet);
 
 
 void Log(const char* string);

--- a/Log.h
+++ b/Log.h
@@ -20,7 +20,7 @@ std::string FormatPlayerNetID(int playerNetID);
 
 void Log(const char* string);
 
-void LogAddress(const sockaddr_in &addr);
+void LogAddress(const sockaddr_in& addr);
 void LogAddressList(const PeerInfo* peerInfo);
-void LogGuid(const GUID &guid);
+void LogGuid(const GUID& guid);
 void LogPacket(const OP2Internal::Packet& packet);

--- a/Log.h
+++ b/Log.h
@@ -14,6 +14,10 @@ namespace OP2Internal {
 extern std::ofstream logFile;
 
 
+std::string FormatIP4Address(unsigned long ip);
+std::string FormatPlayerNetID(int playerNetID);
+
+
 void Log(const char* string);
 
 void LogAddress(sockaddr_in &addr);


### PR DESCRIPTION
Extract body of Log methods into Format methods that return strings. Switches the Log methods to delegate to the corresponding Format method.
