### PR TITLE
Use safe versions of str functions

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -57,7 +57,7 @@ extern "C" __declspec(dllexport) void InitMod(char* iniSectionName)
 	}
 
 	// Store the .ini section name
-	strncpy(sectionName, iniSectionName, sizeof(sectionName));
+	strncpy_s(sectionName, iniSectionName, sizeof(sectionName));
 
 	int protocolIndex;
 	// Get button index to replace functionality of

--- a/OPUNetGameSelectWnd.cpp
+++ b/OPUNetGameSelectWnd.cpp
@@ -653,7 +653,7 @@ void OPUNetGameSelectWnd::OnReceive(Packet &packet)
 		}
 		if (bTwoExternal)
 		{
-			std::strncat(text, "\nWarning: Address and Port-Dependent Mapping detected\nYou may have difficulty joining games.", sizeof(text));
+			strncat(text, "\nWarning: Address and Port-Dependent Mapping detected\nYou may have difficulty joining games.", sizeof(text));
 		}
 		// Update net info text
 		SendDlgItemMessage(this->hWnd, IDC_NetInfo, WM_SETTEXT, 0, (long)&text);

--- a/OPUNetGameSelectWnd.cpp
+++ b/OPUNetGameSelectWnd.cpp
@@ -12,6 +12,7 @@
 #include <objbase.h>
 #include <shlobj.h>
 #include <stdio.h>
+#include <cstring>
 
 #include "OPUNetGameSelectWnd.h"
 #include "OPUNetTransportLayer.h"
@@ -652,7 +653,7 @@ void OPUNetGameSelectWnd::OnReceive(Packet &packet)
 		}
 		if (bTwoExternal)
 		{
-			strncat_s(text, "\nWarning: Address and Port-Dependent Mapping detected\nYou may have difficulty joining games.", sizeof(text));
+			std::strncat(text, "\nWarning: Address and Port-Dependent Mapping detected\nYou may have difficulty joining games.", sizeof(text));
 		}
 		// Update net info text
 		SendDlgItemMessage(this->hWnd, IDC_NetInfo, WM_SETTEXT, 0, (long)&text);

--- a/OPUNetGameSelectWnd.cpp
+++ b/OPUNetGameSelectWnd.cpp
@@ -643,7 +643,7 @@ void OPUNetGameSelectWnd::OnReceive(Packet &packet)
 
 		// Build new net info text string
 		char text[128];
-		_snprintf(text, sizeof(text), "External IP: %d.%d.%d.%d:%d", (externalIp.s_addr & 255), (externalIp.s_addr >> 8 & 255), (externalIp.s_addr >> 16 & 255), (externalIp.s_addr >> 24 & 255), externalPort);
+		_snprintf_s(text, sizeof(text), "External IP: %d.%d.%d.%d:%d", (externalIp.s_addr & 255), (externalIp.s_addr >> 8 & 255), (externalIp.s_addr >> 16 & 255), (externalIp.s_addr >> 24 & 255), externalPort);
 		// Check if internal address received
 		if (bReceivedInternal)
 		{
@@ -652,7 +652,7 @@ void OPUNetGameSelectWnd::OnReceive(Packet &packet)
 		}
 		if (bTwoExternal)
 		{
-			strncat(text, "\nWarning: Address and Port-Dependent Mapping detected\nYou may have difficulty joining games.", sizeof(text));
+			strncat_s(text, "\nWarning: Address and Port-Dependent Mapping detected\nYou may have difficulty joining games.", sizeof(text));
 		}
 		// Update net info text
 		SendDlgItemMessage(this->hWnd, IDC_NetInfo, WM_SETTEXT, 0, (long)&text);

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -173,8 +173,8 @@ logFile << "Bound to server port: " << port << std::endl;
 	hostedGameInfo.createGameInfo.startupFlags.missionType = gameType;
 	hostedGameInfo.createGameInfo.startupFlags.numInitialVehicles = 0;
 	// Copy the game creator name and password
-	strncpy(hostedGameInfo.createGameInfo.gameCreatorName, creatorName, sizeof(hostedGameInfo.createGameInfo.gameCreatorName));
-	strncpy(this->password, password, sizeof(this->password));
+	strncpy_s(hostedGameInfo.createGameInfo.gameCreatorName, creatorName, sizeof(hostedGameInfo.createGameInfo.gameCreatorName));
+	strncpy_s(this->password, password, sizeof(this->password));
 
 // **DEBUG**
 logFile << " Session ID: ";
@@ -299,7 +299,7 @@ bool OPUNetTransportLayer::JoinGame(HostedGameInfo &game, const char* password)
 	packet.tlMessage.joinRequest.commandType = tlcJoinRequest;
 	packet.tlMessage.joinRequest.sessionIdentifier = game.sessionIdentifier;
 	packet.tlMessage.joinRequest.returnPortNum = forcedPort;
-	strncpy(packet.tlMessage.joinRequest.password, password, sizeof(packet.tlMessage.joinRequest.password));
+	strncpy_s(packet.tlMessage.joinRequest.password, password, sizeof(packet.tlMessage.joinRequest.password));
 
 // **DEBUG**
 logFile << "Sending join request: ";


### PR DESCRIPTION
I think we wanted to move away from using the _s versions, but they were pretty much a dropin change which was a lot easier than redesigning all these parts to use std::string and less error prone I think.