### PR TITLE
Move GetOutpost2Directory function

### DIFF
--- a/FileSystemHelper.cpp
+++ b/FileSystemHelper.cpp
@@ -1,0 +1,19 @@
+#include "FileSystemHelper.h"
+#include "op2ext.h"
+
+std::string GetOutpost2Directory()
+{
+	std::string buffer;
+
+	// Pass size of 0 to get exact buffer size
+	std::size_t bufferSize = GetGameDir_s(&buffer[0], 0);
+
+	buffer.resize(bufferSize);
+	GetGameDir_s(&buffer[0], bufferSize);
+
+	// String concatinations (string1 + string2) will not provide expected results
+	// if the std::string explicity has a null terminator
+	buffer.erase(std::find(buffer.begin(), buffer.end(), '\0'), buffer.end());
+
+	return buffer;
+}

--- a/FileSystemHelper.h
+++ b/FileSystemHelper.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+std::string GetOutpost2Directory();

--- a/Log.cpp
+++ b/Log.cpp
@@ -1,5 +1,6 @@
 #include "Log.h"
 #include "OPUNetTransportLayer.h"
+#include "FileSystemHelper.h"
 #include <winsock2.h>
 #include <objbase.h>
 #include <iostream>
@@ -9,7 +10,7 @@
 
 
 // Global Debug file
-std::ofstream logFile("log.txt");
+std::ofstream logFile(GetOutpost2Directory() + "log.txt");
 
 
 std::string FormatAddress(const sockaddr_in& address)

--- a/Main.cpp
+++ b/Main.cpp
@@ -23,7 +23,6 @@ const int ExpectedOutpost2Addr = 0x00400000;
 
 // Provide error in modal dialog box for user and then log message
 void LogWithModalDialog(const std::string& message);
-std::string GetOutpost2Directory();
 
 
 BOOL APIENTRY DllMain(HANDLE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
@@ -65,8 +64,7 @@ extern "C" __declspec(dllexport) void InitMod(char* iniSectionName)
 	strncpy_s(sectionName, iniSectionName, sizeof(sectionName));
 
 	// Get multiplayer button index that NetFix will replace
-	const std::string iniPath = GetOutpost2Directory() + "Outpost2.ini";
-	int protocolIndex = GetPrivateProfileInt(sectionName, "ProtocolIndex", DefaultProtocolIndex, iniPath.c_str());
+	int protocolIndex = config.GetInt(sectionName, "ProtocolIndex", DefaultProtocolIndex);
 	logFile << "[" << sectionName << "]" << " ProtocolIndex = " << protocolIndex << std::endl;
 	// Set a new multiplayer protocol type
 	protocolList[protocolIndex].netGameProtocol = &opuNetGameProtocol;
@@ -77,21 +75,4 @@ void LogWithModalDialog(const std::string& message)
 {
 	Log(message.c_str());
 	MessageBox(nullptr, message.c_str(), "NetFixClient Error", 0);
-}
-
-std::string GetOutpost2Directory()
-{
-	std::string buffer;
-
-	// Pass size of 0 to get exact buffer size
-	std::size_t bufferSize = GetGameDir_s(&buffer[0], 0);
-
-	buffer.resize(bufferSize);
-	GetGameDir_s(&buffer[0], bufferSize);
-
-	// String concatinations (string1 + string2) will not provide expected results
-	// if the std::string explicity has a null terminator
-	buffer.erase(std::find(buffer.begin(), buffer.end(), '\0'), buffer.end());
-
-	return buffer;
 }

--- a/NetFixClient.sln
+++ b/NetFixClient.sln
@@ -9,7 +9,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "OP2Internal", "OP2Internal\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "op2ext", "op2ext\op2ext.vcxproj", "{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Outpost2DLL", "op2ext\Submodules\Outpost2DLL\Outpost2DLL.vcxproj", "{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Outpost2DLL", "op2ext\Outpost2DLL\Outpost2DLL.vcxproj", "{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/NetFixClient.vcxproj
+++ b/NetFixClient.vcxproj
@@ -115,6 +115,7 @@
     <ResourceCompile Include="CustomDialogScript.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="FileSystemHelper.cpp" />
     <ClCompile Include="Log.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="OPUNetGameSelectWnd.cpp" />
@@ -122,6 +123,7 @@
     <ClCompile Include="ValidatePacket.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="FileSystemHelper.h" />
     <ClInclude Include="Log.h" />
     <ClInclude Include="OPUNetGameProtocol.h" />
     <ClInclude Include="OPUNetGameSelectWnd.h" />

--- a/NetFixClient.vcxproj.filters
+++ b/NetFixClient.vcxproj.filters
@@ -31,6 +31,9 @@
     <ClCompile Include="Log.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="FileSystemHelper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="OPUNetGameProtocol.h">
@@ -46,6 +49,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="FileSystemHelper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Use GetOutpost2Directory to prevent NetFixClient logger from logging in environment path when a debugger is attached. (This likely won't be a problem in the future if we remove the local logger)

Use OP2Internal specific function when getting the default protocol index. Simpler call and still works proper with debugger attached.

Closes #1