### PR TITLE
Fix directory to op2ext in MSVC solution file

### DIFF
--- a/NetFixClient.sln
+++ b/NetFixClient.sln
@@ -9,7 +9,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "OP2Internal", "OP2Internal\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "op2ext", "op2ext\op2ext.vcxproj", "{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Outpost2DLL", "op2ext\Submodules\Outpost2DLL\Outpost2DLL.vcxproj", "{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Outpost2DLL", "op2ext\Outpost2DLL\Outpost2DLL.vcxproj", "{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Ok, I was reading the comment in PR #48 and trying to figure out what was going on. I think I've got it figured out, and this branch is my test of that.

In commit 3e4f2588d5535390d4ba4a797a1bc7a3e1981767 the op2ext submodule was updated. This was done directly on master. There was no branch or PR, and so CI did not run before the changes were added to master. This caused a CI failure on the master branch:
https://ci.appveyor.com/project/OPU/netfixclient/builds/23441784

The fix was then added in 5188eee5782dc47deec09887489d1dbfa73db7fa on the MoveGetOutpost2DirFunction branch, rather than being applied to master or a new branch.

I created this branch, and cherry picked that commit mostly to get CI to run on this change. As it seems to fix master, I'm going to go ahead and merge it right away.
