### PR TITLE
Add missing header

### DIFF
--- a/FileSystemHelper.cpp
+++ b/FileSystemHelper.cpp
@@ -1,5 +1,6 @@
 #include "FileSystemHelper.h"
 #include "op2ext.h"
+#include <algorithm>
 
 std::string GetOutpost2Directory()
 {


### PR DESCRIPTION
The `std::find` method is found in `<algorithm>`.

Mingw flags this as a compile error.
