### PR TITLE
Continue using op2 ext logger

### DIFF
--- a/Log.cpp
+++ b/Log.cpp
@@ -85,7 +85,7 @@ std::string FormatPacket(const OP2Internal::Packet& packet)
 	ss << " Size  : " << static_cast<unsigned int>(packet.header.sizeOfPayload) << std::endl;
 	ss << " type  : " << static_cast<unsigned int>(packet.header.type) << std::endl;
 	ss << " checksum : " << std::hex << packet.Checksum() << std::dec << std::endl;
-	ss << " commandType : " << packet.tlMessage.tlHeader.commandType << std::endl;
+	ss << " commandType : " << packet.tlMessage.tlHeader.commandType; //Final endl adding by Log function
 
 	return ss.str();
 }
@@ -99,9 +99,4 @@ void Log(const std::string& message)
 void LogAddressList(const PeerInfo* peerInfo)
 {
 	logFile << FormatPlayerList(peerInfo); // Note: std::endl already included
-}
-
-void LogPacket(const OP2Internal::Packet& packet)
-{
-	logFile << FormatPacket(packet); // Note: std::endl already included
 }

--- a/Log.cpp
+++ b/Log.cpp
@@ -101,11 +101,6 @@ void LogAddressList(const PeerInfo* peerInfo)
 	logFile << FormatPlayerList(peerInfo); // Note: std::endl already included
 }
 
-void LogGuid(const GUID& guid)
-{
-	logFile << FormatGuid(guid); // Note: No std::endl;
-}
-
 void LogPacket(const OP2Internal::Packet& packet)
 {
 	logFile << FormatPacket(packet); // Note: std::endl already included

--- a/Log.cpp
+++ b/Log.cpp
@@ -48,7 +48,7 @@ std::string FormatPlayerList(const PeerInfo* peerInfo)
 		ss << FormatAddress(peerInfo[i].address);
 		ss << ", ";
 		ss << FormatPlayerNetID(peerInfo[i].playerNetID);
-		ss << "}" << std::endl;
+		ss << "}";
 	}
 
 	return ss.str();
@@ -94,9 +94,4 @@ std::string FormatPacket(const OP2Internal::Packet& packet)
 void Log(const std::string& message)
 {
 	op2ext::Log(message.c_str());
-}
-
-void LogAddressList(const PeerInfo* peerInfo)
-{
-	logFile << FormatPlayerList(peerInfo); // Note: std::endl already included
 }

--- a/Log.h
+++ b/Log.h
@@ -26,4 +26,3 @@ std::string FormatPacket(const OP2Internal::Packet& packet);
 void Log(const std::string& message);
 
 void LogAddressList(const PeerInfo* peerInfo);
-void LogPacket(const OP2Internal::Packet& packet);

--- a/Log.h
+++ b/Log.h
@@ -24,5 +24,3 @@ std::string FormatPacket(const OP2Internal::Packet& packet);
 
 
 void Log(const std::string& message);
-
-void LogAddressList(const PeerInfo* peerInfo);

--- a/Log.h
+++ b/Log.h
@@ -26,5 +26,4 @@ std::string FormatPacket(const OP2Internal::Packet& packet);
 void Log(const std::string& message);
 
 void LogAddressList(const PeerInfo* peerInfo);
-void LogGuid(const GUID& guid);
 void LogPacket(const OP2Internal::Packet& packet);

--- a/Main.cpp
+++ b/Main.cpp
@@ -1,8 +1,7 @@
 #include "OPUNetGameProtocol.h"
 #include "Log.h"
-// Force Exports from Outpost2.exe
 #include <OP2Internal.h>
-#define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <string>
 
@@ -25,7 +24,7 @@ BOOL APIENTRY DllMain(HANDLE hModule, DWORD  ul_reason_for_call, LPVOID lpReserv
 	case DLL_PROCESS_ATTACH:
 		// Don't need this, so don't waste the time
 		DisableThreadLibraryCalls((HMODULE)hModule);
-		// Store the module handle
+
 		hInstance = (HINSTANCE)hModule;
 
 		break;

--- a/Main.cpp
+++ b/Main.cpp
@@ -7,9 +7,7 @@
 using namespace OP2Internal;
 
 #include "OPUNetGameProtocol.h"
-#include <cstddef>
 #include <string>
-#include <algorithm>
 
 
 HINSTANCE hInstance;

--- a/Main.cpp
+++ b/Main.cpp
@@ -7,12 +7,9 @@
 using namespace OP2Internal;
 
 #include "OPUNetGameProtocol.h"
-#include <fstream>
 #include <cstddef>
 #include <string>
 #include <algorithm>
-
-extern std::ofstream logFile;
 
 
 HINSTANCE hInstance;
@@ -65,7 +62,7 @@ extern "C" __declspec(dllexport) void InitMod(char* iniSectionName)
 
 	// Get multiplayer button index that NetFix will replace
 	int protocolIndex = config.GetInt(sectionName, "ProtocolIndex", DefaultProtocolIndex);
-	logFile << "[" << sectionName << "]" << " ProtocolIndex = " << protocolIndex << std::endl;
+	Log("ProtocolIndex set to " + std::to_string(protocolIndex));
 	// Set a new multiplayer protocol type
 	protocolList[protocolIndex].netGameProtocol = &opuNetGameProtocol;
 }

--- a/Main.cpp
+++ b/Main.cpp
@@ -1,14 +1,12 @@
+#include "OPUNetGameProtocol.h"
 #include "Log.h"
-#define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
-#include <windows.h>
-
 // Force Exports from Outpost2.exe
 #include <OP2Internal.h>
-using namespace OP2Internal;
-
-#include "OPUNetGameProtocol.h"
+#define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
+#include <windows.h>
 #include <string>
 
+using namespace OP2Internal;
 
 HINSTANCE hInstance;
 OPUNetGameProtocol opuNetGameProtocol;

--- a/OPUNetGameSelectWnd.cpp
+++ b/OPUNetGameSelectWnd.cpp
@@ -5,7 +5,10 @@
 // Have listed games timeout eventually and remove from list
 //  (on receive of new hosted game?)  (the list is cleared if they click search)
 
-
+#include "OPUNetGameSelectWnd.h"
+#include "OPUNetTransportLayer.h"
+#include "Log.h"
+#include "resource.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <mmsystem.h>
@@ -14,11 +17,6 @@
 #include <stdio.h>
 #include <cstring>
 #include <string>
-
-#include "OPUNetGameSelectWnd.h"
-#include "OPUNetTransportLayer.h"
-#include "Log.h"
-#include "resource.h"
 
 
 extern char sectionName[];

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -300,7 +300,7 @@ bool OPUNetTransportLayer::JoinGame(HostedGameInfo &game, const char* password)
 // **DEBUG**
 Log("Sending join request: " + FormatAddress(game.address));
 Log("  Session ID: " + FormatGuid(packet.tlMessage.joinRequest.sessionIdentifier));
-//LogPacket(packet);
+//Log(FormatPacket(packet));
 
 	sockaddr_in gameServerAddr;
 	// Check if a Game Server is set

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -177,9 +177,7 @@ logFile << "Bound to server port: " << port << std::endl;
 	strncpy_s(this->password, password, sizeof(this->password));
 
 // **DEBUG**
-logFile << " Session ID: ";
-LogGuid(hostedGameInfo.sessionIdentifier);
-logFile << std::endl;
+Log(" Session ID: " + FormatGuid(hostedGameInfo.sessionIdentifier));
 
 	// Create a Host playerNetID
 	playerNetID = timeGetTime() & ~7;
@@ -301,9 +299,7 @@ bool OPUNetTransportLayer::JoinGame(HostedGameInfo &game, const char* password)
 
 // **DEBUG**
 Log("Sending join request: " + FormatAddress(game.address));
-logFile << "  Session ID: ";
-LogGuid(packet.tlMessage.joinRequest.sessionIdentifier);
-logFile << std::endl;
+Log("  Session ID: " + FormatGuid(packet.tlMessage.joinRequest.sessionIdentifier));
 //LogPacket(packet);
 
 	sockaddr_in gameServerAddr;

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -336,8 +336,8 @@ void OPUNetTransportLayer::OnJoinAccepted(Packet &packet)
 	peerInfo[localPlayerNum].address.sin_addr.s_addr = INADDR_ANY;	// Clear the address
 	peerInfo[localPlayerNum].status = 2;
 
-logFile << "OnJoinAcecpted" << std::endl;
-LogAddressList(peerInfo);
+Log("OnJoinAcecpted");
+Log(FormatPlayerList(peerInfo));
 
 	// Update num players (for quit messages from cancelled games)
 	numPlayers = 1;
@@ -1230,8 +1230,8 @@ logFile << "GameStarting" << std::endl;
 				}
 
 // **DEBUG**
-logFile << "Replicated Players List:" << std::endl;
-LogAddressList(peerInfo);
+Log("Replicated Players List:");
+Log(FormatPlayerList(peerInfo));
 
 				// Form a new packet to return to the game
 				packet.header.sourcePlayerNetID = 0;


### PR DESCRIPTION
Decided to break and submit current work for review. Partly because I was starting to work refactors that were not directly associated to the logging work and partly because we need to address what to do when the host log file is created:

```C++
bool OPUNetTransportLayer::HostGame(USHORT port, const char* password, const char* creatorName, int maxPlayers, int gameType)
{
	int i;
	int errorCode;
	sockaddr_in localAddress;

// **DEBUG**
logFile.close();
logFile.open("logHost.txt");
```

I was thinking of just tagging all messages that would be logged in the host log file as 

DATETIME [MODULE] Host | original message

If that sounds reasonable I'll work to it, otherwise we can open an issue and discuss more. My thought right now is to limit to one log file if we can, but not sure what final exact formatting should look like.

-Brett