### PR TITLE
Remove abort/success return comments when return value does not need …

### DIFF
--- a/OPUNetGameSelectWnd.cpp
+++ b/OPUNetGameSelectWnd.cpp
@@ -243,7 +243,7 @@ void OPUNetGameSelectWnd::InitNetLayer()
 	{
 		// Error creating the transport layer
 		EndDialog(this->hWnd, true);		// bCancel = true
-		return;								// Abort
+		return;
 	}
 
 	// Set the global NetTransportLayer object pointer
@@ -263,7 +263,7 @@ bool OPUNetGameSelectWnd::InitGurManager()
 	{
 		// Failed to create the Guaranteed Send Layer. Inform User
 		SetStatusText("Out of memory.  Could not create Guaranteed Send Layer.");
-		return false;			// Abort
+		return false;
 	}
 	// Initialize the Guaranteed Send Layer
 	const int errorCode = app.gurManager->Initialize(opuNetTransportLayer);
@@ -272,10 +272,10 @@ bool OPUNetGameSelectWnd::InitGurManager()
 	{
 		// Failed to initialize. Inform user
 		SetStatusText("Failed to Initialize the Guaranteed Send Layer");
-		return false;			// Abort
+		return false;
 	}
 
-	return true;		// Success
+	return true;
 }
 
 
@@ -539,7 +539,7 @@ void OPUNetGameSelectWnd::OnReceive(Packet &packet)
 		{
 			// Out of memory. Inform user
 			SetStatusText("Out of memory");
-			return;						// Abort
+			return;
 		}
 
 		// Copy the packet info
@@ -717,9 +717,8 @@ void OPUNetGameSelectWnd::OnJoinAccepted()
 	// Initialize the Guaranteed Send Layer
 	int errorCode = InitGurManager();
 	// Check for errors
-	if (errorCode == 0)
-	{
-		return;		// Abort
+	if (errorCode == 0) {
+		return;
 	}
 
 
@@ -807,7 +806,7 @@ void OPUNetGameSelectWnd::OnClickJoin()
 	{
 		// No game selected  (or selected item is not a game)
 		SetStatusText("Please select a game to join");
-		return;				// Abort
+		return;
 	}
 
 
@@ -867,9 +866,8 @@ void OPUNetGameSelectWnd::OnClickCreate()
 	// Initialize the Guaranteed Send Layer
 	errorCode = InitGurManager();
 	// Check for errors
-	if (errorCode == 0)
-	{
-		return;		// Abort
+	if (errorCode == 0) {
+		return;
 	}
 
 	

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -341,10 +341,8 @@ Log(FormatPlayerList(peerInfo));
 
 	// Send updated status to host
 	bool bSuccess = SendStatusUpdate();
-	// Check for errors replying
-	if (bSuccess == false)
-	{
-		// Error. Inform User
+
+	if (!bSuccess) {
 		MsgBox(nullptr, "Error sending updated status to host", "Error", 0);
 	}
 

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -200,7 +200,7 @@ logFile << "Error informing game server" << std::endl;
 
 
 	// Return success status
-	return true;				// Success
+	return true;
 }
 
 bool OPUNetTransportLayer::GetExternalAddress()
@@ -595,7 +595,7 @@ int OPUNetTransportLayer::Send(Packet& packet)
 		}
 	}
 
-	return true;		// Success
+	return true;
 }
 
 int OPUNetTransportLayer::Receive(Packet& packet)
@@ -750,7 +750,7 @@ int OPUNetTransportLayer::GetAddressString(int playerNetID, char* addressString,
 	sockaddr_in* address = &peerInfo[playerIndex].address;
 	scr_snprintf(addressString, bufferSize, "%i.%i.%i.%i", address->sin_addr.S_un.S_un_b.s_b1, address->sin_addr.S_un.S_un_b.s_b2, address->sin_addr.S_un.S_un_b.s_b3, address->sin_addr.S_un.S_un_b.s_b4);
 
-	return true;		// Success
+	return true;
 }
 
 int OPUNetTransportLayer::ResetTrafficCounters()
@@ -759,7 +759,7 @@ int OPUNetTransportLayer::ResetTrafficCounters()
 	memset(&trafficCounters, 0, sizeof(trafficCounters));
 	trafficCounters.timeOfLastReset = timeGetTime();
 
-	return true;		// Success
+	return true;
 }
 
 int OPUNetTransportLayer::GetTrafficCounts(TrafficCounters& trafficCounters)
@@ -767,7 +767,7 @@ int OPUNetTransportLayer::GetTrafficCounts(TrafficCounters& trafficCounters)
 	// Copy the TrafficCounter to the supplied buffer
 	trafficCounters = this->trafficCounters;
 
-	return true;		// Success
+	return true;
 }
 
 
@@ -944,7 +944,7 @@ int OPUNetTransportLayer::ReadSocket(SOCKET sourceSocket, Packet& packet, sockad
 {
 	// Check if the host socket is in use
 	if (sourceSocket == INVALID_SOCKET) {
-		return -1;		// Abort
+		return -1;
 	}
 
 	// Check the server port for data
@@ -952,10 +952,10 @@ int OPUNetTransportLayer::ReadSocket(SOCKET sourceSocket, Packet& packet, sockad
 	int errorCode = ioctlsocket(sourceSocket, FIONREAD, &numBytes);
 	// Check for success
 	if (errorCode == SOCKET_ERROR) {
-		return -1;		// Abort
+		return -1;
 	}
 	if (numBytes == 0) {
-		return -1;		// Abort
+		return -1;
 	}
 
 	// Read the data
@@ -964,7 +964,7 @@ int OPUNetTransportLayer::ReadSocket(SOCKET sourceSocket, Packet& packet, sockad
 
 	// Check for errors
 	if (numBytes == SOCKET_ERROR) {
-		return -1;		// Abort
+		return -1;
 	}
 
 	// Return number of bytes read
@@ -1361,10 +1361,10 @@ bool OPUNetTransportLayer::GetGameServerAddress(sockaddr_in &gameServerAddress)
 	// Convert the address string to a sockaddr_in struct
 	int errorCode = GetHostAddress(addressString, gameServerAddress);
 	if (errorCode == -1) {
-		return true;		// Success
+		return true;
 	}
 	
-	return false;		// Error
+	return false;
 }
 
 void OPUNetTransportLayer::GetGameServerAddressString(char* gameServerAddressString, int maxLength)


### PR DESCRIPTION
…commenting

I thought it would help to pull some of the comments out. If this doesn't seem desirable, please reject.

Thanks,
Brett