### PR TITLE
Remove log file

### DIFF
--- a/Log.cpp
+++ b/Log.cpp
@@ -7,12 +7,7 @@ namespace op2ext {
 #include <winsock2.h>
 #include <objbase.h>
 #include <iostream>
-#include <fstream>
 #include <sstream>
-
-
-// Global Debug file
-std::ofstream logFile(GetOutpost2Directory() + "log.txt");
 
 
 std::string FormatAddress(const sockaddr_in& address)

--- a/Log.h
+++ b/Log.h
@@ -1,4 +1,3 @@
-#include <fstream>
 #include <string>
 
 struct sockaddr_in;
@@ -9,10 +8,6 @@ struct PeerInfo;
 namespace OP2Internal {
 	struct Packet;
 };
-
-
-// Global Debug file
-extern std::ofstream logFile;
 
 
 std::string FormatAddress(const sockaddr_in& address);

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -1113,7 +1113,7 @@ bool OPUNetTransportLayer::DoImmediateProcessing(Packet &packet, sockaddr_in &fr
 			{
 				tlMessage.tlHeader.commandType = tlcJoinGranted;
 				// **DEBUG**
-				Log("Client join accepted: " + FormatAddress(fromAddress) + 
+				Log("Client join accepted: " + FormatAddress(fromAddress) + ". New Player Net ID: " +
 					FormatPlayerNetID(tlMessage.joinReply.newPlayerNetID));
 
 				// Check if a forced return port has been set

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -663,7 +663,7 @@ int OPUNetTransportLayer::Receive(Packet& packet)
 
 
 		// **DEBUG**
-		//Log("ReadSocket: type = " + std::to_string(static_cast<int>(packet.header.type))
+		//Log("ReadSocket: type = " + std::to_string(packet.header.type)
 		//		+ "  commandType = " + std::to_string(packet.tlMessage.tlHeader.commandType)
 		//		+ "  sourcePlayerNetID = " + std::to_string(packet.header.sourcePlayerNetID));
 
@@ -691,7 +691,7 @@ int OPUNetTransportLayer::Receive(Packet& packet)
 			{
 				Log("Received packet with bad sourcePlayerNetID: " + std::to_string(sourcePlayerNetID) + 
 					" from " + FormatAddress(fromAddress));
-				Log(" Packet.type = " + std::to_string(static_cast<int>(packet.header.type)));
+				Log(" Packet.type = " + std::to_string(packet.header.type));
 				Log(" Packet.commandType = " + std::to_string(packet.tlMessage.tlHeader.commandType));
 			}
 		}

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -1119,7 +1119,7 @@ bool OPUNetTransportLayer::DoImmediateProcessing(Packet &packet, sockaddr_in &fr
 				// Check if a forced return port has been set
 				if (returnPortNum != 0)
 				{
-					logFile << "Return Port forced to " << returnPortNum << std::endl;
+					Log("Return Port forced to " + std::to_string(returnPortNum));
 					// Set the new return port number
 					peerInfo[tlMessage.joinReply.newPlayerNetID & 7].address.sin_port = returnPortNum;
 				}

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -94,8 +94,8 @@ bool OPUNetTransportLayer::CreateSocket()
 
 bool OPUNetTransportLayer::HostGame(USHORT port, const char* password, const char* creatorName, int maxPlayers, int gameType)
 {
-// **DEBUG**
-Log("Hosting Game");
+	// **DEBUG**
+	Log("Hosting Game");
 
 	// Clear internal players state
 	numPlayers = 0;
@@ -146,8 +146,8 @@ Log("Hosting Game");
 			hostSocket = netSocket;
 		}
 
-// **DEBUG**
-Log("Bound to server port: " + std::to_string(port));
+	// **DEBUG**
+	Log("Bound to server port: " + std::to_string(port));
 	}
 
 
@@ -171,8 +171,8 @@ Log("Bound to server port: " + std::to_string(port));
 	strncpy_s(hostedGameInfo.createGameInfo.gameCreatorName, creatorName, sizeof(hostedGameInfo.createGameInfo.gameCreatorName));
 	strncpy_s(this->password, password, sizeof(this->password));
 
-// **DEBUG**
-Log(" Session ID: " + FormatGuid(hostedGameInfo.sessionIdentifier));
+	// **DEBUG**
+	Log(" Session ID: " + FormatGuid(hostedGameInfo.sessionIdentifier));
 
 	// Create a Host playerNetID
 	playerNetID = timeGetTime() & ~7;
@@ -193,8 +193,8 @@ Log(" Host playerNetID: " + FormatPlayerNetID(playerNetID));
 	// Check for errors
 	if (errorCode == 0)
 	{
-// **DEBUG**
-Log("Error informing game server");
+	// **DEBUG**
+	Log("Error informing game server");
 	}
 
 
@@ -259,7 +259,7 @@ bool OPUNetTransportLayer::SearchForGames(char* hostAddressString, unsigned shor
 	packet.tlMessage.searchQuery.timeStamp = timeGetTime();
 	packet.tlMessage.searchQuery.password[0] = 0;
 
-// **DEBUG**
+	// **DEBUG**
 	Log("Search for games: " + FormatAddress(hostAddress));
 
 	// Send the HostGameSearchQuery
@@ -292,10 +292,10 @@ bool OPUNetTransportLayer::JoinGame(HostedGameInfo &game, const char* password)
 	packet.tlMessage.joinRequest.returnPortNum = forcedPort;
 	strncpy_s(packet.tlMessage.joinRequest.password, password, sizeof(packet.tlMessage.joinRequest.password));
 
-// **DEBUG**
-Log("Sending join request: " + FormatAddress(game.address));
-Log("  Session ID: " + FormatGuid(packet.tlMessage.joinRequest.sessionIdentifier));
-//Log(FormatPacket(packet));
+	// **DEBUG**
+	Log("Sending join request: " + FormatAddress(game.address));
+	Log("  Session ID: " + FormatGuid(packet.tlMessage.joinRequest.sessionIdentifier));
+	//Log(FormatPacket(packet));
 
 	sockaddr_in gameServerAddr;
 	// Check if a Game Server is set
@@ -331,8 +331,8 @@ void OPUNetTransportLayer::OnJoinAccepted(Packet &packet)
 	peerInfo[localPlayerNum].address.sin_addr.s_addr = INADDR_ANY;	// Clear the address
 	peerInfo[localPlayerNum].status = 2;
 
-Log("OnJoinAcecpted");
-Log(FormatPlayerList(peerInfo));
+	Log("OnJoinAcecpted");
+	Log(FormatPlayerList(peerInfo));
 
 	// Update num players (for quit messages from cancelled games)
 	numPlayers = 1;
@@ -662,10 +662,10 @@ int OPUNetTransportLayer::Receive(Packet& packet)
 		}
 
 
-// **DEBUG**
-//Log("ReadSocket: type = " + std::to_string(static_cast<int>(packet.header.type))
-//		+ "  commandType = " + std::to_string(packet.tlMessage.tlHeader.commandType)
-//		+ "  sourcePlayerNetID = " + std::to_string(packet.header.sourcePlayerNetID));
+		// **DEBUG**
+		//Log("ReadSocket: type = " + std::to_string(static_cast<int>(packet.header.type))
+		//		+ "  commandType = " + std::to_string(packet.tlMessage.tlHeader.commandType)
+		//		+ "  sourcePlayerNetID = " + std::to_string(packet.header.sourcePlayerNetID));
 
 		// Error check the packet
 		if (numBytes < sizeof(PacketHeader)) {
@@ -975,7 +975,7 @@ int OPUNetTransportLayer::ReadSocket(SOCKET sourceSocket, Packet& packet, sockad
 
 bool OPUNetTransportLayer::SendTo(Packet& packet, sockaddr_in& to)
 {
-//Log("SendTo: Packet.commandType = " + std::to_string(packet.tlMessage.tlHeader.commandType));
+	//Log("SendTo: Packet.commandType = " + std::to_string(packet.tlMessage.tlHeader.commandType));
 
 	// Calculate Packet size
 	int packetSize = packet.header.sizeOfPayload + sizeof(packet.header);
@@ -1016,7 +1016,7 @@ bool OPUNetTransportLayer::SendStatusUpdate()
 	packet.tlMessage.tlHeader.commandType = tlcUpdateStatus;
 	packet.tlMessage.statusUpdate.newStatus = peerInfo[playerNetID & 7].status;		// Copy local status
 
-//Log("SendStatusUpdate()");
+	//Log("SendStatusUpdate()");
 
 	// Send the new status to the host
 	return SendTo(packet, peerInfo[0].address);
@@ -1139,7 +1139,8 @@ bool OPUNetTransportLayer::DoImmediateProcessing(Packet &packet, sockaddr_in &fr
 			if (packet.header.sizeOfPayload != sizeof(HostedGameSearchQuery)) {
 				return true;		// Packet handled (discard)
 			}
-// **DEBUG**
+
+			// **DEBUG**
 			Log("Game Search Query: " + FormatAddress(fromAddress));
 
 			// Verify Game Identifier
@@ -1197,8 +1198,8 @@ bool OPUNetTransportLayer::DoImmediateProcessing(Packet &packet, sockaddr_in &fr
 		switch (tlMessage.tlHeader.commandType)
 		{
 		case tlcStartGame:
-// **DEBUG**
-Log("GameStarting");
+			// **DEBUG**
+			Log("GameStarting");
 			break;
 		case tlcSetPlayersList:
 			// Verify packet size
@@ -1223,9 +1224,9 @@ Log("GameStarting");
 					peerInfo[i].playerNetID = tlMessage.playersList.netPeerInfo[i].playerNetID;
 				}
 
-// **DEBUG**
-Log("Replicated Players List:");
-Log(FormatPlayerList(peerInfo));
+				// **DEBUG**
+				Log("Replicated Players List:");
+				Log(FormatPlayerList(peerInfo));
 
 				// Form a new packet to return to the game
 				packet.header.sourcePlayerNetID = 0;
@@ -1279,7 +1280,7 @@ Log(FormatPlayerList(peerInfo));
 			return true;			// Packet handled
 
 		case tlcHostedGameSearchReply:		// [Custom format]
-// **DEBUG**
+			// **DEBUG**
 			Log("Hosted Game Search Reply: " + FormatAddress(fromAddress));
 
 			// Verify packet size

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -1114,7 +1114,7 @@ bool OPUNetTransportLayer::DoImmediateProcessing(Packet &packet, sockaddr_in &fr
 				tlMessage.tlHeader.commandType = tlcJoinGranted;
 				// **DEBUG**
 				Log("Client join accepted: " + FormatAddress(fromAddress) + 
-					" (" + std::to_string(tlMessage.joinReply.newPlayerNetID) + ")");
+					FormatPlayerNetID(tlMessage.joinReply.newPlayerNetID));
 
 				// Check if a forced return port has been set
 				if (returnPortNum != 0)
@@ -1398,8 +1398,8 @@ void OPUNetTransportLayer::CheckSourcePort(Packet &packet, sockaddr_in &from)
 			Log("Packet from player " + std::to_string(sourcePlayerIndex) + 
 				" (" + FormatAddress(from) + ") received on unexpected port (" + 
 				std::to_string(ntohs(sourcePort)) + " instead of " + 
-				std::to_string(ntohs(expectedPort)) + ")  [PlayerNetId: " + 
-				std::to_string(sourcePlayerNetId) + "]");
+				std::to_string(ntohs(expectedPort)) + 
+				") PlayerNetId: " + FormatPlayerNetID(sourcePlayerNetId));
 		}
 		// Update the source port
 		sourcePlayerPeerInfo.address.sin_port = sourcePort;

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -322,7 +322,7 @@ void OPUNetTransportLayer::OnJoinAccepted(Packet &packet)
 	// Store the Host info
 	peerInfo[0].playerNetID = packet.header.sourcePlayerNetID;	// Store Host playerNetID
 	peerInfo[0].address = joiningGameInfo->address;				// Store Host address
-	peerInfo[0].status = 2;										// **
+	peerInfo[0].status = 2;
 	// Get the assigned playerNetID
 	playerNetID = packet.tlMessage.joinReply.newPlayerNetID;	// Store playerNetID
 	int localPlayerNum = playerNetID & 7;   // Cache (frequently used)
@@ -478,7 +478,7 @@ int OPUNetTransportLayer::ReplicatePlayersList()
 
 
 	// Success
-	peerInfo[0].status = 3;			// **
+	peerInfo[0].status = 3;
 	return 1;
 }
 
@@ -921,7 +921,7 @@ int OPUNetTransportLayer::AddPlayer(sockaddr_in& from)
 			// -----------------------------
 			// Store the source address
 			peerInfo[newPlayerIndex].address = from;
-			peerInfo[newPlayerIndex].status = 1;			// **
+			peerInfo[newPlayerIndex].status = 1;
 			peerInfo[newPlayerIndex].playerNetID = newPlayerIndex | (timeGetTime() & ~7);
 			// Increase connected player count
 			numPlayers++;
@@ -1244,8 +1244,8 @@ bool OPUNetTransportLayer::DoImmediateProcessing(Packet &packet, sockaddr_in &fr
 
 			return true;			// Packet handled
 		case tlcSetPlayersListFailed:
-			peerInfo[0].status = 4;						// **
-			peerInfo[playerNetID & 7].status = 4;		// **
+			peerInfo[0].status = 4;
+			peerInfo[playerNetID & 7].status = 4;
 
 			// Form a new packet to return to the game
 			packet.header.sizeOfPayload = 4;

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -7,7 +7,7 @@
 #include <windows.h>
 #include <mmsystem.h>
 #include <objbase.h>
-
+#include <string>
 
 extern char sectionName[];
 
@@ -79,11 +79,11 @@ bool OPUNetTransportLayer::CreateSocket()
 		// Check for success
 		if (retVal == 0)
 		{
-			logFile << "ForcedPort = " << forcedPort << std::endl;
+			Log("ForcedPort = " + std::to_string(forcedPort));
 		}
 		else
 		{
-			logFile << "Warning: Could not bind to ForcedPort = " << forcedPort << std::endl;
+			Log("Warning: Could not bind to ForcedPort = " + std::to_string(forcedPort));
 			forcedPort = 0;		// Clear this so we don't try to use it when joining games
 		}
 	}
@@ -95,8 +95,7 @@ bool OPUNetTransportLayer::CreateSocket()
 bool OPUNetTransportLayer::HostGame(USHORT port, const char* password, const char* creatorName, int maxPlayers, int gameType)
 {
 // **DEBUG**
-logFile.close();
-logFile.open("logHost.txt");
+Log("Hosting Game");
 
 	// Clear internal players state
 	numPlayers = 0;
@@ -148,7 +147,7 @@ logFile.open("logHost.txt");
 		}
 
 // **DEBUG**
-logFile << "Bound to server port: " << port << std::endl;
+Log("Bound to server port: " + std::to_string(port));
 	}
 
 
@@ -177,7 +176,7 @@ Log(" Session ID: " + FormatGuid(hostedGameInfo.sessionIdentifier));
 
 	// Create a Host playerNetID
 	playerNetID = timeGetTime() & ~7;
-logFile << " Host playerNetID: " << playerNetID << std::endl;
+Log(" Host playerNetID: " + FormatPlayerNetID(playerNetID));
 	// Set the host fields
 	peerInfo[0].playerNetID = playerNetID;
 	peerInfo[0].address = localAddress;			// Clear the local address
@@ -195,7 +194,7 @@ logFile << " Host playerNetID: " << playerNetID << std::endl;
 	if (errorCode == 0)
 	{
 // **DEBUG**
-logFile << "Error informing game server" << std::endl;
+Log("Error informing game server");
 	}
 
 
@@ -664,9 +663,9 @@ int OPUNetTransportLayer::Receive(Packet& packet)
 
 
 // **DEBUG**
-//logFile << "ReadSocket: type = " << (int)packet.header.type
-//		<< "  commandType = " << packet.tlMessage.tlHeader.commandType
-//		<< "  sourcePlayerNetID = " << packet.header.sourcePlayerNetID << endl;
+//Log("ReadSocket: type = " + std::to_string(static_cast<int>(packet.header.type))
+//		+ "  commandType = " + std::to_string(packet.tlMessage.tlHeader.commandType)
+//		+ "  sourcePlayerNetID = " + std::to_string(packet.header.sourcePlayerNetID));
 
 		// Error check the packet
 		if (numBytes < sizeof(PacketHeader)) {
@@ -692,8 +691,8 @@ int OPUNetTransportLayer::Receive(Packet& packet)
 			{
 				Log("Received packet with bad sourcePlayerNetID: " + std::to_string(sourcePlayerNetID) + 
 					" from " + FormatAddress(fromAddress));
-				logFile << " Packet.type = " << (int)packet.header.type << std::endl;
-				logFile << " Packet.commandType = " << packet.tlMessage.tlHeader.commandType << std::endl;
+				Log(" Packet.type = " + std::to_string(static_cast<int>(packet.header.type)));
+				Log(" Packet.commandType = " + std::to_string(packet.tlMessage.tlHeader.commandType));
 			}
 		}
 
@@ -976,7 +975,7 @@ int OPUNetTransportLayer::ReadSocket(SOCKET sourceSocket, Packet& packet, sockad
 
 bool OPUNetTransportLayer::SendTo(Packet& packet, sockaddr_in& to)
 {
-//logFile << "SendTo: Packet.commandType = " << packet.tlMessage.tlHeader.commandType << endl;
+//Log("SendTo: Packet.commandType = " + std::to_string(packet.tlMessage.tlHeader.commandType));
 
 	// Calculate Packet size
 	int packetSize = packet.header.sizeOfPayload + sizeof(packet.header);
@@ -997,7 +996,7 @@ bool OPUNetTransportLayer::SendTo(Packet& packet, sockaddr_in& to)
 	{
 		// **DEBUG**
 		Log("SendTo error: " + FormatAddress(to));
-		logFile << WSAGetLastError() << std::endl;
+		Log(std::to_string(WSAGetLastError()));
 	}
 
 	return (errorCode != SOCKET_ERROR);
@@ -1017,7 +1016,7 @@ bool OPUNetTransportLayer::SendStatusUpdate()
 	packet.tlMessage.tlHeader.commandType = tlcUpdateStatus;
 	packet.tlMessage.statusUpdate.newStatus = peerInfo[playerNetID & 7].status;		// Copy local status
 
-//logFile << "SendStatusUpdate()" << endl;
+//Log("SendStatusUpdate()");
 
 	// Send the new status to the host
 	return SendTo(packet, peerInfo[0].address);
@@ -1199,7 +1198,7 @@ bool OPUNetTransportLayer::DoImmediateProcessing(Packet &packet, sockaddr_in &fr
 		{
 		case tlcStartGame:
 // **DEBUG**
-logFile << "GameStarting" << std::endl;
+Log("GameStarting");
 			break;
 		case tlcSetPlayersList:
 			// Verify packet size
@@ -1372,7 +1371,7 @@ void OPUNetTransportLayer::GetGameServerAddressString(char* gameServerAddressStr
 	// Get the address string
 	config.GetString(sectionName, "GameServerAddr", gameServerAddressString, maxLength, "");
 
-	logFile << "[" << sectionName << "]" << " GameServerAddr = " << gameServerAddressString << std::endl;
+	Log("GameServerAddr = " + std::string(gameServerAddressString));
 }
 
 


### PR DESCRIPTION
This fully removes the log file. I've done some limited testing. See attached log file. I attempted to host a game, cancelled, tried to join without a game available, and then clicked search. 

I think the next step is spending time decided how the message logging should actually look (or maybe it is okay). Some information may be lost, since the host log file is no longer created.

-Brett