### PR TITLE
Fix mingw warnings

### DIFF
--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -945,27 +945,27 @@ int OPUNetTransportLayer::ReadSocket(SOCKET sourceSocket, Packet& packet, sockad
 	}
 
 	// Check the server port for data
-	unsigned long numBytes;
-	int errorCode = ioctlsocket(sourceSocket, FIONREAD, &numBytes);
-	// Check for success
+	unsigned long byteCountUnsigned; //ioctlsocket sets argp to number of bytes read when passed FIONREAD
+	int errorCode = ioctlsocket(sourceSocket, FIONREAD, &byteCountUnsigned);
+
 	if (errorCode == SOCKET_ERROR) {
 		return -1;
 	}
-	if (numBytes == 0) {
+
+	if (byteCountUnsigned == 0) {
 		return -1;
 	}
 
 	// Read the data
 	int fromLen = sizeof(from);
-	numBytes = recvfrom(sourceSocket, (char*)&packet, sizeof(packet), 0, (sockaddr*)&from, &fromLen);
+	auto receivedByteCount = recvfrom(sourceSocket, (char*)&packet, sizeof(packet), 0, (sockaddr*)&from, &fromLen);
 
-	// Check for errors
-	if (numBytes == SOCKET_ERROR) {
+	if (receivedByteCount == SOCKET_ERROR) {
 		return -1;
 	}
 
 	// Return number of bytes read
-	return numBytes;
+	return receivedByteCount;
 }
 
 

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -666,7 +666,7 @@ int OPUNetTransportLayer::Receive(Packet& packet)
 		//		+ "  sourcePlayerNetID = " + std::to_string(packet.header.sourcePlayerNetID));
 
 		// Error check the packet
-		if (numBytes < sizeof(PacketHeader)) {
+		if (static_cast<std::size_t>(numBytes) < sizeof(PacketHeader)) {
 			continue;		// Discard packet
 		}
 		if (static_cast<std::size_t>(numBytes) < sizeof(PacketHeader) + packet.header.sizeOfPayload) {

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -958,7 +958,8 @@ int OPUNetTransportLayer::ReadSocket(SOCKET sourceSocket, Packet& packet, sockad
 
 	// Read the data
 	int fromLen = sizeof(from);
-	auto receivedByteCount = recvfrom(sourceSocket, (char*)&packet, sizeof(packet), 0, (sockaddr*)&from, &fromLen);
+	auto receivedByteCount = recvfrom(sourceSocket, reinterpret_cast<char*>(&packet), 
+		sizeof(packet), 0, reinterpret_cast<sockaddr*>(&from), &fromLen);
 
 	if (receivedByteCount == SOCKET_ERROR) {
 		return -1;

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -945,14 +945,14 @@ int OPUNetTransportLayer::ReadSocket(SOCKET sourceSocket, Packet& packet, sockad
 	}
 
 	// Check the server port for data
-	unsigned long byteCountUnsigned; //ioctlsocket sets argp to number of bytes read when passed FIONREAD
-	int errorCode = ioctlsocket(sourceSocket, FIONREAD, &byteCountUnsigned);
+	unsigned long byteCount; // ioctlsocket sets argp to number of bytes read when passed FIONREAD
+	int errorCode = ioctlsocket(sourceSocket, FIONREAD, &byteCount);
 
 	if (errorCode == SOCKET_ERROR) {
 		return -1;
 	}
 
-	if (byteCountUnsigned == 0) {
+	if (byteCount == 0) {
 		return -1;
 	}
 

--- a/OPUNetTransportLayer.cpp
+++ b/OPUNetTransportLayer.cpp
@@ -647,7 +647,7 @@ int OPUNetTransportLayer::Receive(Packet& packet)
 
 		// Try to read from the net socket
 		sockaddr_in fromAddress;
-		unsigned long numBytes = ReadSocket(netSocket, packet, fromAddress);
+		auto numBytes = ReadSocket(netSocket, packet, fromAddress);
 		// Check for errors
 		if (numBytes == -1)
 		{
@@ -669,7 +669,7 @@ int OPUNetTransportLayer::Receive(Packet& packet)
 		if (numBytes < sizeof(PacketHeader)) {
 			continue;		// Discard packet
 		}
-		if (numBytes < sizeof(PacketHeader) + packet.header.sizeOfPayload) {
+		if (static_cast<std::size_t>(numBytes) < sizeof(PacketHeader) + packet.header.sizeOfPayload) {
 			continue;		// Discard packet
 		}
 		if (packet.header.checksum != packet.Checksum()) {


### PR DESCRIPTION
Closes #66

@DanRStevens, could you check my work closely. I have never used reinterpret_cast or the win32 functions associated with the changes.

I was able to create a game lobby and have another instance of Outpost 2 join it on my computer. The level didn't start properly, although I don't know if that is because I was using NetFixClient on my CPU with two instances of Outpost 2 or not. 

-Brett 