### PR TITLE
Prevent Visual Studio from sorting header and .cpp files into separate filters

### DIFF
--- a/NetFixClient.vcxproj.filters
+++ b/NetFixClient.vcxproj.filters
@@ -1,58 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Source Files">
-      <UniqueIdentifier>{1ba320f0-a1c5-4f27-90f0-6fbf90de93f8}</UniqueIdentifier>
-      <Extensions>cpp;c;cxx;rc;def;r;odl;idl;hpj;bat</Extensions>
-    </Filter>
-    <Filter Include="Header Files">
-      <UniqueIdentifier>{a9a68c0b-fb13-412c-acda-ed9a8f2c457e}</UniqueIdentifier>
-      <Extensions>h;hpp;hxx;hm;inl</Extensions>
-    </Filter>
+    <ResourceCompile Include="CustomDialogScript.rc"/>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="CustomDialogScript.rc">
-      <Filter>Source Files</Filter>
-    </ResourceCompile>
+    <ClCompile Include="Main.cpp"/>
+    <ClCompile Include="OPUNetGameSelectWnd.cpp"/>
+    <ClCompile Include="OPUNetTransportLayer.cpp"/>
+    <ClCompile Include="ValidatePacket.cpp"/>
+    <ClCompile Include="Log.cpp"/>
+    <ClCompile Include="FileSystemHelper.cpp"/>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="Main.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="OPUNetGameSelectWnd.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="OPUNetTransportLayer.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="ValidatePacket.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Log.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="FileSystemHelper.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="OPUNetGameProtocol.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="OPUNetGameSelectWnd.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="OPUNetTransportLayer.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Log.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="resource.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="FileSystemHelper.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
+    <ClInclude Include="OPUNetGameProtocol.h"/>
+    <ClInclude Include="OPUNetGameSelectWnd.h"/>
+    <ClInclude Include="OPUNetTransportLayer.h"/>
+    <ClInclude Include="Log.h"/>
+    <ClInclude Include="resource.h"/>
+    <ClInclude Include="FileSystemHelper.h"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Improves workflow for me in VS. I think it also makes more sense logically not to separate all headers from cpp files in the IDE.

Based on branch UpdateSubmodules