### PR TITLE
Change timer base type from UINT to UINT_PTR

### DIFF
--- a/OPUNetGameSelectWnd.h
+++ b/OPUNetGameSelectWnd.h
@@ -50,7 +50,7 @@ private:
 private:
 	// Member variables
 	OPUNetTransportLayer* opuNetTransportLayer;
-	UINT timer;
+	UINT_PTR timer;
 	UINT searchTickCount;
 	HostedGameInfo* joiningGame;
 	char password[16];


### PR DESCRIPTION
Based off of comments from PR #74.

No warnings seemed to be produced by MSVC.