### PR TITLE
Define platform agnostic type for port (unsigned short)

### DIFF
--- a/client/OPUNetGameSelectWnd.cpp
+++ b/client/OPUNetGameSelectWnd.cpp
@@ -6,7 +6,6 @@
 //  (on receive of new hosted game?)  (the list is cleared if they click search)
 
 #include "OPUNetGameSelectWnd.h"
-#include "OPUNetTransportLayer.h"
 #include "Log.h"
 #include "resource.h"
 #define WIN32_LEAN_AND_MEAN

--- a/client/OPUNetGameSelectWnd.h
+++ b/client/OPUNetGameSelectWnd.h
@@ -56,8 +56,8 @@ private:
 	char joinRequestPassword[16];
 	UINT joinAttempt;
 	UINT joinAttemptTickCount;
-	port internalPort;
-	port externalPort;
+	Port internalPort;
+	Port externalPort;
 	in_addr externalIp;
 	bool bReceivedInternal;
 	bool bTwoExternal;

--- a/client/OPUNetGameSelectWnd.h
+++ b/client/OPUNetGameSelectWnd.h
@@ -1,8 +1,7 @@
+#include "OPUNetTransportLayer.h"
 #include <OP2Internal.h>
-using namespace OP2Internal;
 
-class OPUNetTransportLayer;
-struct HostedGameInfo;
+using namespace OP2Internal;
 
 const int MaxServerAddressLen = 128;
 const int timerInterval = 50;
@@ -57,8 +56,8 @@ private:
 	char joinRequestPassword[16];
 	UINT joinAttempt;
 	UINT joinAttemptTickCount;
-	USHORT internalPort;
-	USHORT externalPort;
+	port internalPort;
+	port externalPort;
 	in_addr externalIp;
 	bool bReceivedInternal;
 	bool bTwoExternal;

--- a/client/OPUNetTransportLayer.cpp
+++ b/client/OPUNetTransportLayer.cpp
@@ -92,7 +92,7 @@ bool OPUNetTransportLayer::CreateSocket()
 	return (netSocket != INVALID_SOCKET);
 }
 
-bool OPUNetTransportLayer::HostGame(USHORT port, const char* hostPassword, const char* creatorName, int maxPlayers, int gameType)
+bool OPUNetTransportLayer::HostGame(port port, const char* hostPassword, const char* creatorName, int maxPlayers, int gameType)
 {
 	// Clear internal players state
 	numPlayers = 0;
@@ -227,7 +227,7 @@ bool OPUNetTransportLayer::GetExternalAddress()
 	return errorCode;
 }
 
-bool OPUNetTransportLayer::SearchForGames(char* hostAddressString, unsigned short defaultHostPort)
+bool OPUNetTransportLayer::SearchForGames(char* hostAddressString, port defaultHostPort)
 {
 	// Create the default host address
 	sockaddr_in hostAddress;

--- a/client/OPUNetTransportLayer.cpp
+++ b/client/OPUNetTransportLayer.cpp
@@ -92,7 +92,7 @@ bool OPUNetTransportLayer::CreateSocket()
 	return (netSocket != INVALID_SOCKET);
 }
 
-bool OPUNetTransportLayer::HostGame(port port, const char* hostPassword, const char* creatorName, int maxPlayers, int gameType)
+bool OPUNetTransportLayer::HostGame(Port port, const char* hostPassword, const char* creatorName, int maxPlayers, int gameType)
 {
 	// Clear internal players state
 	numPlayers = 0;
@@ -227,7 +227,7 @@ bool OPUNetTransportLayer::GetExternalAddress()
 	return errorCode;
 }
 
-bool OPUNetTransportLayer::SearchForGames(char* hostAddressString, port defaultHostPort)
+bool OPUNetTransportLayer::SearchForGames(char* hostAddressString, Port defaultHostPort)
 {
 	// Create the default host address
 	sockaddr_in hostAddress;

--- a/client/OPUNetTransportLayer.h
+++ b/client/OPUNetTransportLayer.h
@@ -4,6 +4,13 @@
 #define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 
+// Type alias to handle different type names used by winsock and POSIX socket implementations
+#ifdef WIN32
+using port = u_short;
+#else
+using port = in_port_t;
+#endif
+
 using namespace OP2Internal;
 
 
@@ -41,8 +48,8 @@ public:
 
 	// Following functions: Return true on success, false on failure
 	bool CreateSocket();
-	bool HostGame(USHORT port, const char* hostPassword, const char* creatorName, int maxPlayers, int gameType);
-	bool SearchForGames(char* hostAddressString, unsigned short defaultHostPort);
+	bool HostGame(port port, const char* hostPassword, const char* creatorName, int maxPlayers, int gameType);
+	bool SearchForGames(char* hostAddressString, port defaultHostPort);
 	bool JoinGame(HostedGameInfo &game, const char* joinRequestPassword);
 	// Externally triggered events
 	void OnJoinAccepted(Packet &packet);

--- a/client/OPUNetTransportLayer.h
+++ b/client/OPUNetTransportLayer.h
@@ -6,9 +6,9 @@
 
 // Type alias to handle different type names used by winsock and POSIX socket implementations
 #ifdef WIN32
-using port = u_short;
+using Port = u_short;
 #else
-using port = in_port_t;
+using Port = in_port_t;
 #endif
 
 using namespace OP2Internal;
@@ -48,8 +48,8 @@ public:
 
 	// Following functions: Return true on success, false on failure
 	bool CreateSocket();
-	bool HostGame(port port, const char* hostPassword, const char* creatorName, int maxPlayers, int gameType);
-	bool SearchForGames(char* hostAddressString, port defaultHostPort);
+	bool HostGame(Port port, const char* hostPassword, const char* creatorName, int maxPlayers, int gameType);
+	bool SearchForGames(char* hostAddressString, Port defaultHostPort);
 	bool JoinGame(HostedGameInfo &game, const char* joinRequestPassword);
 	// Externally triggered events
 	void OnJoinAccepted(Packet &packet);


### PR DESCRIPTION
Closes #91 

I noticed in #91 it was Port. I went with port here since I seem to basic types as all lowercase or uppercase. Not opposed to Port though if desired.