### PR TITLE
Use static cast to hide warning comparing signed to unsigned type in …

### DIFF
--- a/client/OPUNetGameSelectWnd.cpp
+++ b/client/OPUNetGameSelectWnd.cpp
@@ -108,7 +108,7 @@ int OPUNetGameSelectWnd::DlgProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 		controlId = wParam;
 		notifyCode = ((NMHDR*)lParam)->code;
 
-		if ((controlId == IDC_GamesList) && (notifyCode == NM_DBLCLK))
+		if ((controlId == IDC_GamesList) && (notifyCode == static_cast<UINT>(NM_DBLCLK)))
 		{
 			OnClickJoin();
 			return true;			// Message processed


### PR DESCRIPTION
…OPUNetGameSelectWnd::DlgProc

Warning C26454 Arithmetic overflow: '-' operation produces a negative unsigned result at compile time (io.5). NetFixClient \NETFIXCLIENT\CLIENT\OPUNETGAMESELECTWND.CPP 111

Closes #97 