### PR TITLE
Add a tool tip to represent server address

### DIFF
--- a/client/CustomDialogScript.rc
+++ b/client/CustomDialogScript.rc
@@ -51,7 +51,7 @@ BEGIN
                     WS_TABSTOP
     LTEXT           "Game Join Info",IDC_STATIC,7,111,287,8
     GROUPBOX        "",IDC_STATIC,7,117,287,136
-    LTEXT           "Server &Address :",IDC_STATIC,13,128,72,8
+    LTEXT           "Server &Address :",IDC_ServerAddressLabel,13,128,72,8
     COMBOBOX        IDC_ServerAddress,90,126,198,120,CBS_DROPDOWN | 
                     WS_VSCROLL | WS_TABSTOP
     LTEXT           "&Games",IDC_STATIC,13,140,275,8

--- a/client/OPUNetGameSelectWnd.h
+++ b/client/OPUNetGameSelectWnd.h
@@ -48,6 +48,8 @@ private:
 	void AddServerAddress(const char* address);
 	void SetStatusText(const char* text);
 
+	void CreateServerAddressToolTip();
+
 private:
 	OPUNetTransportLayer* opuNetTransportLayer;
 	UINT_PTR timer;

--- a/client/resource.h
+++ b/client/resource.h
@@ -15,6 +15,7 @@
 #define IDC_ServerAddress               1014
 #define IDC_StatusBar                   1018
 #define IDC_NetInfo                     1020
+#define IDC_ServerAddressLabel          1021
 
 // Next default values for new objects
 // 
@@ -22,7 +23,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        105
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1021
+#define _APS_NEXT_CONTROL_VALUE         1022
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif


### PR DESCRIPTION
Currently, tool tip shows when the server address label is under the cursor. It doesn't seem to work when applied over the server address combo box

I tried placing the tool tip text into a string table resource and then pulling it by calling LoadString. Unfortunately, I couldn't seem to get it to work well. Probably not a big deal for this application.