### PR TITLE
Improve function returns within on immediate packet process

### DIFF
--- a/client/OPUNetTransportLayer.cpp
+++ b/client/OPUNetTransportLayer.cpp
@@ -1070,9 +1070,11 @@ bool OPUNetTransportLayer::OnImmediatePacketProcess(Packet& packet, const sockad
 		switch (tlMessage.tlHeader.commandType)
 		{
 		case TransportLayerCommand::JoinRequest:
-			return OnJoinRequest(packet, fromAddress, tlMessage);
+			OnJoinRequest(packet, fromAddress, tlMessage);
+			return true;
 		case TransportLayerCommand::HostedGameSearchQuery:
-			return OnHostedGameSearchQuery(packet, fromAddress, tlMessage);
+			OnHostedGameSearchQuery(packet, fromAddress, tlMessage);
+			return true;
 		case TransportLayerCommand::JoinHelpRequest:
 			if (OnJoinHelpRequest(packet, fromAddress, tlMessage)) {
 				return true;
@@ -1108,15 +1110,15 @@ bool OPUNetTransportLayer::OnImmediatePacketProcess(Packet& packet, const sockad
 	return false; // Unhandled (non-immediate) message
 }
 
-bool OPUNetTransportLayer::OnJoinRequest(Packet& packet, const sockaddr_in& fromAddress, TransportLayerMessage& tlMessage)
+void OPUNetTransportLayer::OnJoinRequest(Packet& packet, const sockaddr_in& fromAddress, TransportLayerMessage& tlMessage)
 {
 	// Verify packet size
 	if (packet.header.sizeOfPayload != sizeof(JoinRequest)) {
-		return true;		// Packet handled (discard)
+		return; // Packet handled (discard)
 	}
 	// Check the session identifier
 	if (packet.tlMessage.joinRequest.sessionIdentifier != hostedGameInfo.sessionIdentifier) {
-		return true;		// Packet handled (discard)
+		return; // Packet handled (discard)
 	}
 
 	int returnPortNum = tlMessage.joinRequest.returnPortNum;
@@ -1149,25 +1151,25 @@ bool OPUNetTransportLayer::OnJoinRequest(Packet& packet, const sockaddr_in& from
 	// Send the reply
 	SendTo(packet, fromAddress);
 
-	return true;			// Packet handled
+	return; // Packet handled
 }
 
-bool OPUNetTransportLayer::OnHostedGameSearchQuery(Packet& packet, const sockaddr_in& fromAddress, TransportLayerMessage& tlMessage)
+void OPUNetTransportLayer::OnHostedGameSearchQuery(Packet& packet, const sockaddr_in& fromAddress, TransportLayerMessage& tlMessage)
 {
 	// Verify packet size
 	if (packet.header.sizeOfPayload != sizeof(HostedGameSearchQuery)) {
-		return true;		// Packet handled (discard)
+		return; // Packet handled (discard)
 	}
 
 	LogDebug("Game Search Query: " + FormatAddress(fromAddress));
 
 	// Verify Game Identifier
 	if (tlMessage.searchQuery.gameIdentifier != gameIdentifier) {
-		return true;		// Packet handled (discard)
+		return; // Packet handled (discard)
 	}
 	// Verify password
 	if (strncmp(tlMessage.searchQuery.password, hostPassword, sizeof(hostPassword)) != 0) {
-		return true;		// Packet handled (discard)
+		return; // Packet handled (discard)
 	}
 
 	// Create a reply
@@ -1180,7 +1182,7 @@ bool OPUNetTransportLayer::OnHostedGameSearchQuery(Packet& packet, const sockadd
 	// Send the reply
 	SendTo(packet, fromAddress);
 
-	return true;			// Packet handled
+	return; // Packet handled
 }
 
 bool OPUNetTransportLayer::OnJoinHelpRequest(const Packet& packet, const sockaddr_in& fromAddress, TransportLayerMessage& tlMessage)

--- a/client/OPUNetTransportLayer.cpp
+++ b/client/OPUNetTransportLayer.cpp
@@ -1206,6 +1206,7 @@ bool OPUNetTransportLayer::OnJoinHelpRequest(const Packet& packet, const sockadd
 	}
 	sendto(netSocket, (char*)&packet, 0, 0, (sockaddr*)&packet.tlMessage.joinHelpRequest.clientAddr, sizeof(packet.tlMessage.joinHelpRequest.clientAddr));
 
+	return false;
 }
 
 bool OPUNetTransportLayer::OnSetPlayersList(Packet& packet, const TransportLayerMessage& tlMessage)

--- a/client/OPUNetTransportLayer.h
+++ b/client/OPUNetTransportLayer.h
@@ -86,8 +86,8 @@ private:
 	bool SendStatusUpdate();
 	bool SendUntilStatusUpdate(Packet& packet, PeerStatus untilStatus, int maxTries, int repeatDelay);
 	bool OnImmediatePacketProcess(Packet& packet, const sockaddr_in& fromAddress);
-	bool OnJoinRequest(Packet& packet, const sockaddr_in& fromAddress, TransportLayerMessage& tlMessage);
-	bool OnHostedGameSearchQuery(Packet& packet, const sockaddr_in& fromAddress, TransportLayerMessage& tlMessage);
+	void OnJoinRequest(Packet& packet, const sockaddr_in& fromAddress, TransportLayerMessage& tlMessage);
+	void OnHostedGameSearchQuery(Packet& packet, const sockaddr_in& fromAddress, TransportLayerMessage& tlMessage);
 	bool OnJoinHelpRequest(const Packet& packet, const sockaddr_in& fromAddress, TransportLayerMessage& tlMessage);
 	bool OnSetPlayersList(Packet& packet, const TransportLayerMessage& tlMessage);
 	void OnSetPlayersListFailed(Packet& packet);


### PR DESCRIPTION
The first commit fixes a warning from the circleci automated build about the function not stating return value. 

I think the second commit more clearly shows the reader that those functions always fully process the packet.