### PR TITLE
Silence arithmetic overflow warning

### DIFF
--- a/client/OPUNetGameSelectWnd.cpp
+++ b/client/OPUNetGameSelectWnd.cpp
@@ -107,8 +107,8 @@ int OPUNetGameSelectWnd::DlgProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 		// Get the controlId
 		controlId = wParam;
 		notifyCode = ((NMHDR*)lParam)->code;
-
-		if ((controlId == IDC_GamesList) && (notifyCode == static_cast<UINT>(NM_DBLCLK)))
+#pragma warning(suppress: 26454) // MSVC C26454 produced within expansion of NM_DBLCLK
+		if ((controlId == IDC_GamesList) && (notifyCode == NM_DBLCLK))
 		{
 			OnClickJoin();
 			return true;			// Message processed


### PR DESCRIPTION
I do not believe #pragma suppress will work here since the warning occurs in a header include and not directly in OPUNetGameSelectWnd

Actually closes #97 

I should have checked closer before merging the last branch.