### PR TITLE
Initialize members in header

### DIFF
--- a/client/OPUNetGameSelectWnd.cpp
+++ b/client/OPUNetGameSelectWnd.cpp
@@ -38,19 +38,7 @@ const char* GameTypeName[] =
 
 OPUNetGameSelectWnd::OPUNetGameSelectWnd()
 {
-	opuNetTransportLayer = nullptr;
-	timer = 0;
-	searchTickCount = SearchTickInterval - 1;	// Broadcast right away
-	joiningGame = nullptr;
-	joinAttempt = 0;
-	joinAttemptTickCount = 0;
-	internalPort = 0;
-	externalPort = 0;
 	externalIp.S_un.S_addr = INADDR_ANY;
-	bReceivedInternal = false;
-	bTwoExternal = false;
-	numEchoRequestsSent = 0;
-	echoTick = EchoTickInterval - 1;	// Check external address right away
 }
 
 OPUNetGameSelectWnd::~OPUNetGameSelectWnd()

--- a/client/OPUNetGameSelectWnd.h
+++ b/client/OPUNetGameSelectWnd.h
@@ -55,7 +55,7 @@ private:
 	UINT_PTR timer = 0;
 	UINT searchTickCount = SearchTickInterval - 1;	// Broadcast right away
 	HostedGameInfo* joiningGame = 0;
-	char joinRequestPassword[16];
+	char joinRequestPassword[16] = { 0 };
 	UINT joinAttempt = 0;
 	UINT joinAttemptTickCount = 0;
 	Port internalPort = 0;

--- a/client/OPUNetGameSelectWnd.h
+++ b/client/OPUNetGameSelectWnd.h
@@ -54,8 +54,8 @@ private:
 	OPUNetTransportLayer* opuNetTransportLayer = nullptr;
 	UINT_PTR timer = 0;
 	UINT searchTickCount = SearchTickInterval - 1;	// Broadcast right away
-	HostedGameInfo* joiningGame = 0;
-	char joinRequestPassword[16] = { 0 };
+	HostedGameInfo* joiningGame = nullptr;
+	char joinRequestPassword[16] = { };
 	UINT joinAttempt = 0;
 	UINT joinAttemptTickCount = 0;
 	Port internalPort = 0;

--- a/client/OPUNetGameSelectWnd.h
+++ b/client/OPUNetGameSelectWnd.h
@@ -51,18 +51,18 @@ private:
 	void CreateServerAddressToolTip();
 
 private:
-	OPUNetTransportLayer* opuNetTransportLayer;
-	UINT_PTR timer;
-	UINT searchTickCount;
-	HostedGameInfo* joiningGame;
+	OPUNetTransportLayer* opuNetTransportLayer = nullptr;
+	UINT_PTR timer = 0;
+	UINT searchTickCount = SearchTickInterval - 1;	// Broadcast right away
+	HostedGameInfo* joiningGame = 0;
 	char joinRequestPassword[16];
-	UINT joinAttempt;
-	UINT joinAttemptTickCount;
-	Port internalPort;
-	Port externalPort;
+	UINT joinAttempt = 0;
+	UINT joinAttemptTickCount = 0;
+	Port internalPort = 0;
+	Port externalPort = 0;
 	in_addr externalIp;
-	bool bReceivedInternal;
-	bool bTwoExternal;
-	UCHAR numEchoRequestsSent;
-	UCHAR echoTick;
+	bool bReceivedInternal = false;
+	bool bTwoExternal = false;
+	UCHAR numEchoRequestsSent = 0;
+	UCHAR echoTick = EchoTickInterval - 1;	// Check external address right away
 };


### PR DESCRIPTION
I think this is a little better to manage, although it could have been implemented as a constructor initialization or left alone???

I'm not sure why the password array wasn't initialized as the rest of the private variables. I set it for consistency.