### PR TITLE
Remove extra private keyword in headers

### DIFF
--- a/client/OPUNetGameSelectWnd.h
+++ b/client/OPUNetGameSelectWnd.h
@@ -50,7 +50,6 @@ private:
 
 	void CreateServerAddressToolTip();
 
-private:
 	OPUNetTransportLayer* opuNetTransportLayer = nullptr;
 	UINT_PTR timer = 0;
 	UINT searchTickCount = SearchTickInterval - 1;	// Broadcast right away

--- a/client/OPUNetTransportLayer.h
+++ b/client/OPUNetTransportLayer.h
@@ -100,7 +100,6 @@ private:
 	void SendBroadcast(Packet& packet, int packetSize);
 	void SendSinglecast(Packet& packet, int packetSize);
 
-private:
 	// Gameplay variables
 	unsigned int numPlayers;
 	bool bInitialized;


### PR DESCRIPTION
If this is a style we want to keep, we can close this pull request. Not too big a deal to me, but thought it would be a little better to not repeat public private unless needed in class headers.