### PR TITLE
Reset MaxPlayerNameLength back to 128

### DIFF
--- a/client/OPUNetGameSelectWnd.cpp
+++ b/client/OPUNetGameSelectWnd.cpp
@@ -733,7 +733,7 @@ void OPUNetGameSelectWnd::OnJoinAccepted()
 	// Get the host player name
 	int hostPlayerNetID = app.netTLayer->GetHostPlayerNetID();
 	// Get the Player Name.
-	char playerName[MaxPlayerNameLength];
+	char playerName[16];
 	SendDlgItemMessage(this->hWnd, IDC_PlayerName, WM_GETTEXT, sizeof(playerName), (LPARAM)&playerName);
 
 

--- a/client/OPUNetGameSelectWnd.h
+++ b/client/OPUNetGameSelectWnd.h
@@ -4,7 +4,7 @@
 using namespace OP2Internal;
 
 const int MaxServerAddressLength = 128;
-const int MaxPlayerNameLength = 13;
+const int MaxPlayerNameLength = 128;
 const int timerInterval = 50;
 const int SearchTickInterval = 60;
 const int JoinAttemptInterval = 20;


### PR DESCRIPTION
Setting MaxPlayerNameLength to 13 or 16 caused the error below when OPUNetGameSelectWnd::OnDestroy is called. Tested in Debug mode compilation.

Unhandled exception at 0x1400D929 (NetFixClient.dll) in Outpost2.exe: Stack cookie instrumentation code detected a stack-based buffer overrun.

I didn't notice this until post merge and should have tested better. You would get the bug when calling close in NetFix's window.