### PR TITLE
Refactor OnDestroy

### DIFF
--- a/client/OPUNetGameSelectWnd.cpp
+++ b/client/OPUNetGameSelectWnd.cpp
@@ -313,7 +313,7 @@ void OPUNetGameSelectWnd::OnDestroy()
 	for (int i = 0; i < 10; ++i)
 	{
 		// Get the Server Address
-		const int retVal = SendDlgItemMessage(this->hWnd, IDC_ServerAddress, CB_GETLBTEXT, (WPARAM)i, (LPARAM)serverAddressBuffer);
+		const int retVal = SendDlgItemMessage(this->hWnd, IDC_ServerAddress, CB_GETLBTEXT, static_cast<WPARAM>(i), reinterpret_cast<LPARAM>(serverAddressBuffer));
 		// Check for errors
 		if (retVal != CB_ERR)
 		{

--- a/client/OPUNetGameSelectWnd.cpp
+++ b/client/OPUNetGameSelectWnd.cpp
@@ -303,12 +303,8 @@ void OPUNetGameSelectWnd::OnDestroy()
 		KillTimer(this->hWnd, timer);
 	}
 
-	// Save the PlayerName
 	WritePlayerNameToIniFile();
-
-	// Save the ServerAddress list
 	WriteServerAddressListToIniFile();
-
 	ClearGamesList();
 }
 
@@ -322,11 +318,12 @@ void OPUNetGameSelectWnd::WritePlayerNameToIniFile()
 void OPUNetGameSelectWnd::WriteServerAddressListToIniFile()
 {
 	char serverAddressBuffer[MaxServerAddressLength];
+
 	for (int i = 0; i < 10; ++i)
 	{
 		// Get the Server Address
 		const int retVal = SendDlgItemMessage(this->hWnd, IDC_ServerAddress, CB_GETLBTEXT, static_cast<WPARAM>(i), reinterpret_cast<LPARAM>(serverAddressBuffer));
-		// Check for errors
+
 		if (retVal != CB_ERR)
 		{
 			// Save the string to the file

--- a/client/OPUNetGameSelectWnd.cpp
+++ b/client/OPUNetGameSelectWnd.cpp
@@ -307,6 +307,20 @@ void OPUNetGameSelectWnd::OnDestroy()
 	SavePlayerNameToIniFile();
 
 	// Save the ServerAddress list
+	WriteServerAddressListToIniFile();
+
+	ClearGamesList();
+}
+
+void OPUNetGameSelectWnd::SavePlayerNameToIniFile()
+{
+	char playerNameBuffer[MaxPlayerNameLength];
+	GetDlgItemText(this->hWnd, IDC_PlayerName, playerNameBuffer, sizeof(playerNameBuffer));
+	config.SetString("Game", "Name", playerNameBuffer);
+}
+
+void OPUNetGameSelectWnd::WriteServerAddressListToIniFile()
+{
 	char serverAddressBuffer[MaxServerAddressLength];
 	for (int i = 0; i < 10; ++i)
 	{
@@ -324,15 +338,6 @@ void OPUNetGameSelectWnd::OnDestroy()
 			config.SetString("IPHistory", std::to_string(i).c_str(), nullptr);
 		}
 	}
-
-	ClearGamesList();
-}
-
-void OPUNetGameSelectWnd::SavePlayerNameToIniFile()
-{
-	char playerNameBuffer[MaxPlayerNameLength];
-	GetDlgItemText(this->hWnd, IDC_PlayerName, playerNameBuffer, sizeof(playerNameBuffer));
-	config.SetString("Game", "Name", playerNameBuffer);
 }
 
 void OPUNetGameSelectWnd::OnTimer()

--- a/client/OPUNetGameSelectWnd.cpp
+++ b/client/OPUNetGameSelectWnd.cpp
@@ -304,9 +304,7 @@ void OPUNetGameSelectWnd::OnDestroy()
 	}
 
 	// Save the PlayerName
-	char playerNameBuffer[MaxPlayerNameLength];
-	GetDlgItemText(this->hWnd, IDC_PlayerName, playerNameBuffer, sizeof(playerNameBuffer));
-	config.SetString("Game", "Name", playerNameBuffer);
+	SavePlayerNameToIniFile();
 
 	// Save the ServerAddress list
 	char serverAddressBuffer[MaxServerAddressLength];
@@ -330,6 +328,12 @@ void OPUNetGameSelectWnd::OnDestroy()
 	ClearGamesList();
 }
 
+void OPUNetGameSelectWnd::SavePlayerNameToIniFile()
+{
+	char playerNameBuffer[MaxPlayerNameLength];
+	GetDlgItemText(this->hWnd, IDC_PlayerName, playerNameBuffer, sizeof(playerNameBuffer));
+	config.SetString("Game", "Name", playerNameBuffer);
+}
 
 void OPUNetGameSelectWnd::OnTimer()
 {

--- a/client/OPUNetGameSelectWnd.cpp
+++ b/client/OPUNetGameSelectWnd.cpp
@@ -304,7 +304,7 @@ void OPUNetGameSelectWnd::OnDestroy()
 	}
 
 	// Save the PlayerName
-	SavePlayerNameToIniFile();
+	WritePlayerNameToIniFile();
 
 	// Save the ServerAddress list
 	WriteServerAddressListToIniFile();
@@ -312,7 +312,7 @@ void OPUNetGameSelectWnd::OnDestroy()
 	ClearGamesList();
 }
 
-void OPUNetGameSelectWnd::SavePlayerNameToIniFile()
+void OPUNetGameSelectWnd::WritePlayerNameToIniFile()
 {
 	char playerNameBuffer[MaxPlayerNameLength];
 	GetDlgItemText(this->hWnd, IDC_PlayerName, playerNameBuffer, sizeof(playerNameBuffer));

--- a/client/OPUNetGameSelectWnd.cpp
+++ b/client/OPUNetGameSelectWnd.cpp
@@ -304,20 +304,21 @@ void OPUNetGameSelectWnd::OnDestroy()
 	}
 
 	// Save the PlayerName
-	char keyValue[MaxPlayerNameLength];
-	GetDlgItemText(this->hWnd, IDC_PlayerName, keyValue, sizeof(keyValue));
-	config.SetString("Game", "Name", keyValue);
+	char playerNameBuffer[MaxPlayerNameLength];
+	GetDlgItemText(this->hWnd, IDC_PlayerName, playerNameBuffer, sizeof(playerNameBuffer));
+	config.SetString("Game", "Name", playerNameBuffer);
 
 	// Save the ServerAddress list
+	char serverAddressBuffer[MaxServerAddressLength];
 	for (int i = 0; i < 10; ++i)
 	{
 		// Get the Server Address
-		const int retVal = SendDlgItemMessage(this->hWnd, IDC_ServerAddress, CB_GETLBTEXT, (WPARAM)i, (LPARAM)keyValue);
+		const int retVal = SendDlgItemMessage(this->hWnd, IDC_ServerAddress, CB_GETLBTEXT, (WPARAM)i, (LPARAM)serverAddressBuffer);
 		// Check for errors
 		if (retVal != CB_ERR)
 		{
 			// Save the string to the file
-			config.SetString("IPHistory", std::to_string(i).c_str(), keyValue);
+			config.SetString("IPHistory", std::to_string(i).c_str(), serverAddressBuffer);
 		}
 		else
 		{

--- a/client/OPUNetGameSelectWnd.h
+++ b/client/OPUNetGameSelectWnd.h
@@ -55,7 +55,7 @@ private:
 	void SetGameListItem(int itemIndex, HostedGameInfo* hostedGameInfo);
 	void AddServerAddress(const char* address);
 	void SetStatusText(const char* text);
-	void SavePlayerNameToIniFile();
+	void WritePlayerNameToIniFile();
 	void WriteServerAddressListToIniFile();
 
 	void CreateServerAddressToolTip();

--- a/client/OPUNetGameSelectWnd.h
+++ b/client/OPUNetGameSelectWnd.h
@@ -56,7 +56,7 @@ private:
 	void AddServerAddress(const char* address);
 	void SetStatusText(const char* text);
 	void SavePlayerNameToIniFile();
-
+	void WriteServerAddressListToIniFile();
 
 	void CreateServerAddressToolTip();
 

--- a/client/OPUNetGameSelectWnd.h
+++ b/client/OPUNetGameSelectWnd.h
@@ -55,6 +55,8 @@ private:
 	void SetGameListItem(int itemIndex, HostedGameInfo* hostedGameInfo);
 	void AddServerAddress(const char* address);
 	void SetStatusText(const char* text);
+	void SavePlayerNameToIniFile();
+
 
 	void CreateServerAddressToolTip();
 


### PR DESCRIPTION
This should fix the issue reported in #120 as the specific error was uncovered by @DanRStevens. Also generally refactors OnDestroy

> Setting MaxPlayerNameLength to 13 or 16 caused the error below when OPUNetGameSelectWnd::OnDestroy is called. Tested in Debug mode compilation.

>Unhandled exception at 0x1400D929 (NetFixClient.dll) in Outpost2.exe: Stack cookie instrumentation code detected a stack-based buffer overrun.

>I didn't notice this until post merge and should have tested better. You would get the bug when calling close in NetFix's window.